### PR TITLE
fix deepseek provider API errors caused by missing reasoning_content field

### DIFF
--- a/cmd/juggler/worker/llm_request.go
+++ b/cmd/juggler/worker/llm_request.go
@@ -241,7 +241,8 @@ func (w *ConversationWorker) buildMessages(contexts []ItemContext) []map[string]
 
 	items := w.getTargetItems()
 
-	for _, item := range items {
+	for i := 0; i < len(items); i++ {
+		item := items[i]
 		switch item.Type {
 		case ItemTypeUser:
 			messages = append(messages, buildUserMessageMap(item))
@@ -253,53 +254,80 @@ func (w *ConversationWorker) buildMessages(contexts []ItemContext) []map[string]
 			messages = append(messages, map[string]any{"type": "thinking", "content": item.Content})
 
 		case ItemTypeToolAction:
-			if item.ToolUseID == "" || item.ToolName == "" {
-				w.log.Error("[Worker] WARNING: Tool action skipped - ToolUseID=%q, ToolName=%q", item.ToolUseID, item.ToolName)
-				continue
+			// Collect consecutive tool-action items so tool_use
+			// messages are batched before tool_result messages.
+			// transformMessages groups consecutive tool_use items
+			// into one assistant message (with reasoning_content
+			// replayed via EchoReasoningContent). Interleaving
+			// tool_use/tool_result pairs would produce separate
+			// assistant messages — only the first gets the
+			// reasoning_content, causing DeepSeek's thinking mode
+			// to 400: "The reasoning_content ... must be passed
+			// back to the API."
+			end := i + 1
+			for end < len(items) && items[end].Type == ItemTypeToolAction {
+				end++
+			}
+			toolActions := items[i:end]
+
+			// Emit all tool_use messages first.
+			for _, ta := range toolActions {
+				if ta.ToolUseID == "" || ta.ToolName == "" {
+					w.log.Error("[Worker] WARNING: Tool action skipped - ToolUseID=%q, ToolName=%q", ta.ToolUseID, ta.ToolName)
+					continue
+				}
+				messages = append(messages, buildToolUseMap(ta))
 			}
 
-			messages = append(messages, buildToolUseMap(item))
+			// Emit tool_result messages.
+			for _, ta := range toolActions {
+				if ta.ToolUseID == "" || ta.ToolName == "" {
+					continue
+				}
+				// Tool may not have finished yet if auto-continue raced ahead
+				// of tool execution completing. Emit an explicit isError
+				// tool-result so the LLM treats it as a failure rather than
+				// fabricating reasoning from a misleading "in progress" body.
+				// The strategy loop will re-trigger when the tool finishes;
+				// shipping a lying success body here is the worse outcome.
+				if ta.State != StateCompleted && ta.State != StateCancelled {
+					w.log.Error("WARNING: Tool %s has no result yet — emitting isError tool-result (auto-continue may have raced ahead of execution)", ta.ToolUseID)
+					messages = append(messages, map[string]any{
+						"type":      "tool-result",
+						"toolUseId": ta.ToolUseID,
+						"content":   "[internal] Tool execution did not complete before message build. Do not fabricate output — wait for the actual result.",
+						"isError":   true,
+					})
+					// We just delivered a (placeholder) result for a tool still in
+					// state=running. Stamp the current turn so a mid-turn engine reattach
+					// does NOT reset+re-execute it — the resultFedTurn CURE that removes the
+					// duplicate re-feed at source (doc.go's "Tool-delivery desync" section,
+					// claudecode provider). The stamp self-expires (a later turn carries a
+					// higher turnCounter), so a genuinely-stuck tool can still be recovered
+					// by a future reattach. Store as int: y-crdt's YMap.Set accepts Number
+					// (=int), and convertToYcrdt leaves an int64 untyped for it (see its
+					// float64 case). resetRunningToolsForReattach reads it back numerically.
+					w.doc.UpdateToolActionFieldsRecursive(ta.ToolUseID, map[string]any{
+						"resultFedTurn": int(w.docTurnCounter()),
+					})
+					continue
+				}
 
-			// Tool may not have finished yet if auto-continue raced ahead
-			// of tool execution completing. Emit an explicit isError
-			// tool-result so the LLM treats it as a failure rather than
-			// fabricating reasoning from a misleading "in progress" body.
-			// The strategy loop will re-trigger when the tool finishes;
-			// shipping a lying success body here is the worse outcome.
-			if item.State != StateCompleted && item.State != StateCancelled {
-				w.log.Error("WARNING: Tool %s has no result yet — emitting isError tool-result (auto-continue may have raced ahead of execution)", item.ToolUseID)
-				messages = append(messages, map[string]any{
-					"type":      "tool-result",
-					"toolUseId": item.ToolUseID,
-					"content":   "[internal] Tool execution did not complete before message build. Do not fabricate output — wait for the actual result.",
-					"isError":   true,
-				})
-				// We just delivered a (placeholder) result for a tool still in
-				// state=running. Stamp the current turn so a mid-turn engine reattach
-				// does NOT reset+re-execute it — the resultFedTurn CURE that removes the
-				// duplicate re-feed at source (doc.go's "Tool-delivery desync" section,
-				// claudecode provider). The stamp self-expires (a later turn carries a
-				// higher turnCounter), so a genuinely-stuck tool can still be recovered
-				// by a future reattach. Store as int: y-crdt's YMap.Set accepts Number
-				// (=int), and convertToYcrdt leaves an int64 untyped for it (see its
-				// float64 case). resetRunningToolsForReattach reads it back numerically.
-				w.doc.UpdateToolActionFieldsRecursive(item.ToolUseID, map[string]any{
-					"resultFedTurn": int(w.docTurnCounter()),
-				})
-				continue
+				if rm := buildToolResultMap(ta); rm != nil {
+					messages = append(messages, rm)
+				} else {
+					w.log.Error("FATAL: Tool %s Result unmarshal failed", ta.ToolUseID)
+					messages = append(messages, map[string]any{
+						"type":      "tool-result",
+						"toolUseId": ta.ToolUseID,
+						"content":   "ERROR: Invalid result JSON",
+						"isError":   true,
+					})
+				}
 			}
 
-			if rm := buildToolResultMap(item); rm != nil {
-				messages = append(messages, rm)
-			} else {
-				w.log.Error("FATAL: Tool %s Result unmarshal failed", item.ToolUseID)
-				messages = append(messages, map[string]any{
-					"type":      "tool-result",
-					"toolUseId": item.ToolUseID,
-					"content":   "ERROR: Invalid result JSON",
-					"isError":   true,
-				})
-			}
+			// Advance past the batch we just consumed (-1 because the loop increments).
+			i = end - 1
 
 		case ItemTypeThread:
 			messages = appendThreadMessages(messages, item)

--- a/cmd/juggler/worker/llm_request.go
+++ b/cmd/juggler/worker/llm_request.go
@@ -249,6 +249,9 @@ func (w *ConversationWorker) buildMessages(contexts []ItemContext) []map[string]
 		case ItemTypeAssistant:
 			messages = append(messages, map[string]any{"type": "assistant", "content": item.Content})
 
+		case ItemTypeThinking:
+			messages = append(messages, map[string]any{"type": "thinking", "content": item.Content})
+
 		case ItemTypeToolAction:
 			if item.ToolUseID == "" || item.ToolName == "" {
 				w.log.Error("[Worker] WARNING: Tool action skipped - ToolUseID=%q, ToolName=%q", item.ToolUseID, item.ToolName)


### PR DESCRIPTION
## Problem

(found, fixed and described by deepseek-v4-pro itself)

DeepSeek's thinking mode (`deepseek-v4-pro` with `thinking` enabled) returns `reasoning_content` in streaming responses. On the next turn — especially after tool calls — the API requires this `reasoning_content` to be echoed back on the assistant message. Without it, the API returns:

```
400 Bad Request
{"message":"The `reasoning_content` in the thinking mode must be passed back to the API."}
```

Two bugs in `buildMessages` prevented this.

## Bug 1: Thinking blocks silently dropped

`buildMessages` had no `case ItemTypeThinking:` in its switch. Thinking/reasoning blocks stored in the Yjs doc as `ConversationItem{Type: "thinking"}` were silently skipped when building the next request's message array. The provider layer (`transformMessages`) already handles `"thinking"` messages and replays them as `reasoning_content` on the assistant message (when `EchoReasoningContent` quirk is set, which DeepSeek has) — but the messages never reached it.

**Fix:** Added `case ItemTypeThinking:` that emits `{"type": "thinking", "content": item.Content}`.

## Bug 2: Multiple tool calls split the assistant message

When DeepSeek returns multiple tool calls in one turn (e.g., 4 parallel `read` calls), `buildMessages` interleaved `tool_use` and `tool_result` messages:

```
tool_use₁, tool_result₁, tool_use₂, tool_result₂, tool_use₃, tool_result₃, tool_use₄, tool_result₄
```

`transformMessages` flushes at each `tool_result` boundary, producing **4 separate assistant messages**. Only the first got `reasoning_content` (because `pendingReasoning` is reset after each flush). Assistant messages 2–4 had tool calls but no `reasoning_content`, causing the 400.

**Fix:** Batch consecutive `ItemTypeToolAction` items — emit all `tool_use` messages first, then all `tool_result` messages:

```
tool_use₁, tool_use₂, tool_use₃, tool_use₄, tool_result₁, tool_result₂, tool_result₃, tool_result₄
```

`transformMessages` now produces **one** assistant message with all tool calls + `reasoning_content`, followed by the 4 tool results.

## Files changed

- `cmd/juggler/worker/llm_request.go` — `buildMessages`: added `ItemTypeThinking` case, converted `for range` to index-based loop, added consecutive tool-action batching

## Test plan

<!-- How you verified this. Commands run, scenarios covered. -->

- [ ] `make test` passes
- [ ] `make lint` passes
- [x] Manual verification (describe)

## Notes for reviewers

<!-- Anything specific to call out: trade-offs, follow-ups, files that look bigger than they are. -->
