### PR TITLE
Add Moonshot Kimi provider

### DIFF
--- a/cmd/juggler-test/main.go
+++ b/cmd/juggler-test/main.go
@@ -30,6 +30,7 @@ import (
 	"juggler/cmd/juggler/providers/claudecode"
 	"juggler/cmd/juggler/providers/deepseek"
 	"juggler/cmd/juggler/providers/gemini"
+	"juggler/cmd/juggler/providers/moonshot"
 	"juggler/cmd/juggler/providers/ollama"
 	"juggler/cmd/juggler/providers/openai"
 	"juggler/cmd/juggler/providers/openaicodex"
@@ -52,6 +53,7 @@ func registerProviders() {
 	claudecode.Register()
 	deepseek.Register()
 	gemini.Register()
+	moonshot.Register()
 	ollama.Register()
 	openai.Register()
 	openaicodex.Register()

--- a/cmd/juggler/app/run.go
+++ b/cmd/juggler/app/run.go
@@ -29,6 +29,7 @@ import (
 	"juggler/cmd/juggler/providers/claudecode"
 	"juggler/cmd/juggler/providers/deepseek"
 	"juggler/cmd/juggler/providers/gemini"
+	"juggler/cmd/juggler/providers/moonshot"
 	"juggler/cmd/juggler/providers/ollama"
 	"juggler/cmd/juggler/providers/openai"
 	"juggler/cmd/juggler/providers/openaicodex"
@@ -147,6 +148,7 @@ func registerProviders() {
 	claudecode.Register()
 	deepseek.Register()
 	gemini.Register()
+	moonshot.Register()
 	ollama.Register()
 	openai.Register()
 	openaicodex.Register()

--- a/cmd/juggler/providers/moonshot/client.go
+++ b/cmd/juggler/providers/moonshot/client.go
@@ -1,0 +1,37 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+// Package moonshot provides direct access to Moonshot AI's Kimi models through
+// their OpenAI-compatible Chat Completions API.
+package moonshot
+
+import "juggler/cmd/juggler/providers/openaibase"
+
+const baseURL = "https://api.moonshot.cn/v1"
+
+// Register adds the Moonshot Kimi provider to the global registry. It uses a
+// credential and provider id independent from the user-configured OpenAI-
+// compatible provider, so both can be configured at the same time.
+func Register() {
+	openaibase.Register(openaibase.Descriptor{
+		Name:              "moonshot",
+		DisplayName:       "Moonshot Kimi",
+		Description:       "Kimi models through Moonshot AI's official OpenAI-compatible API. Models are discovered from Moonshot's /v1/models endpoint.",
+		ConfigKeyName:     "moonshot_api_key",
+		EnvVarName:        "MOONSHOT_API_KEY",
+		APIKeyURL:         "https://platform.kimi.com/console/api-keys",
+		DisplayProvider:   "Moonshot Kimi",
+		Filter:            modelFilter,
+		ContextWindowCaps: contextWindowCaps,
+		MaxOutputCaps:     maxOutputCaps,
+		InputModalitiesFn: inputModalities,
+		ThinkingSpecFn:    thinkingSpec,
+		BaseURL:           baseURL,
+		Quirks: openaibase.Quirks{
+			// Kimi thinking models require the complete assistant message,
+			// including reasoning_content, on subsequent tool-call turns.
+			EchoReasoningContent: true,
+		},
+	})
+}

--- a/cmd/juggler/providers/moonshot/models.go
+++ b/cmd/juggler/providers/moonshot/models.go
@@ -1,0 +1,96 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package moonshot
+
+import (
+	"strings"
+
+	"juggler/cmd/juggler/providers/openaibase"
+	provider "juggler/cmd/juggler/providers/registry"
+	"juggler/cmd/juggler/providers/utils"
+)
+
+// The API model catalog supplies model ids but not reliable context/output
+// metadata, so keep documented capability overrides here while discovering the
+// actual list live. Unknown future Kimi models receive conservative defaults.
+const (
+	DefaultContextWindow   = 128000
+	DefaultMaxOutputTokens = 32768
+)
+
+var ModelContextWindows = map[string]int{
+	"kimi-k3":                         1000000,
+	"kimi-k2.7-code":                  256000,
+	"kimi-k2.7-code-highspeed":        256000,
+	"kimi-k2.6":                       256000,
+	"kimi-k2.5":                       256000,
+	"moonshot-v1-8k":                  8000,
+	"moonshot-v1-32k":                 32000,
+	"moonshot-v1-128k":                128000,
+	"moonshot-v1-8k-vision-preview":   8000,
+	"moonshot-v1-32k-vision-preview":  32000,
+	"moonshot-v1-128k-vision-preview": 128000,
+}
+
+// K3's documented default output allowance is 131072 tokens. K2.7/K2.6/K2.5
+// default to 32768. Legacy Moonshot V1 limits include input and output in the
+// named context window, so cap their generated output conservatively.
+var ModelMaxOutputTokens = map[string]int{
+	"kimi-k3":                         131072,
+	"moonshot-v1-8k":                  8000,
+	"moonshot-v1-32k":                 32000,
+	"moonshot-v1-128k":                32768,
+	"moonshot-v1-8k-vision-preview":   8000,
+	"moonshot-v1-32k-vision-preview":  32000,
+	"moonshot-v1-128k-vision-preview": 32768,
+}
+
+var (
+	contextWindowCaps = utils.ModelCaps{Default: DefaultContextWindow, Overrides: ModelContextWindows}
+	maxOutputCaps     = utils.ModelCaps{Default: DefaultMaxOutputTokens, Overrides: ModelMaxOutputTokens}
+)
+
+// modelFilter keeps chat-capable Kimi/Moonshot models while excluding obvious
+// embedding/audio endpoints should they appear in the account catalog.
+func modelFilter(modelID string) bool {
+	id := strings.ToLower(modelID)
+	if !strings.HasPrefix(id, "kimi-") && !strings.HasPrefix(id, "moonshot-") {
+		return false
+	}
+	for _, marker := range []string{"embedding", "tts", "audio"} {
+		if strings.Contains(id, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+func inputModalities(modelID string) []string {
+	id := strings.ToLower(modelID)
+	if strings.HasPrefix(id, "kimi-k3") ||
+		strings.HasPrefix(id, "kimi-k2.7-code") ||
+		strings.HasPrefix(id, "kimi-k2.6") ||
+		strings.HasPrefix(id, "kimi-k2.5") ||
+		strings.Contains(id, "vision") {
+		return []string{"text", "image"}
+	}
+	return nil
+}
+
+// K3 accepts OpenAI-compatible reasoning_effort, currently only "max". K2.x
+// models use Moonshot's separate `thinking` object, so leave their selector
+// hidden and rely on the provider default rather than sending an invalid field.
+func thinkingSpec(modelID string) openaibase.ThinkingSpec {
+	if strings.HasPrefix(strings.ToLower(modelID), "kimi-k3") {
+		return openaibase.ThinkingSpec{
+			Levels:  []string{provider.ThinkingMax},
+			Default: provider.ThinkingMax,
+			Effort: map[string]string{
+				provider.ThinkingMax: "max",
+			},
+		}
+	}
+	return openaibase.ThinkingSpec{}
+}

--- a/cmd/juggler/providers/moonshot/models_test.go
+++ b/cmd/juggler/providers/moonshot/models_test.go
@@ -1,0 +1,91 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package moonshot
+
+import (
+	"reflect"
+	"testing"
+
+	provider "juggler/cmd/juggler/providers/registry"
+)
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	info, ok := provider.GetProviderInfo("moonshot")
+	if !ok {
+		t.Fatal("moonshot provider was not registered")
+	}
+	if info.DisplayName != "Moonshot Kimi" {
+		t.Errorf("display name = %q, want %q", info.DisplayName, "Moonshot Kimi")
+	}
+	if info.ConfigKeyName != "moonshot_api_key" || info.EnvVarName != "MOONSHOT_API_KEY" {
+		t.Errorf("credential metadata = (%q, %q), want independent Moonshot keys", info.ConfigKeyName, info.EnvVarName)
+	}
+	if got := info.ModelContextWindows["kimi-k3"]; got != 1000000 {
+		t.Errorf("registered kimi-k3 context window = %d, want 1000000", got)
+	}
+}
+
+func TestModelFilter(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"kimi-k3", true},
+		{"KIMI-K2.5", true},
+		{"moonshot-v1-128k", true},
+		{"moonshot-v1-8k-vision-preview", true},
+		{"moonshot-embedding-v1", false},
+		{"kimi-audio-preview", false},
+		{"moonshot-tts-v1", false},
+		{"unrelated-chat-model", false},
+	}
+	for _, tc := range cases {
+		if got := modelFilter(tc.model); got != tc.want {
+			t.Errorf("modelFilter(%q) = %v, want %v", tc.model, got, tc.want)
+		}
+	}
+}
+
+func TestModelCapabilities(t *testing.T) {
+	if got := contextWindowCaps.Lookup("kimi-k3"); got != 1000000 {
+		t.Errorf("context window(kimi-k3) = %d, want 1000000", got)
+	}
+	if got := maxOutputCaps.Lookup("kimi-k3"); got != 131072 {
+		t.Errorf("max output(kimi-k3) = %d, want 131072", got)
+	}
+	if got := contextWindowCaps.Lookup("kimi-future"); got != DefaultContextWindow {
+		t.Errorf("context window(unknown) = %d, want default %d", got, DefaultContextWindow)
+	}
+	if got := maxOutputCaps.Lookup("kimi-future"); got != DefaultMaxOutputTokens {
+		t.Errorf("max output(unknown) = %d, want default %d", got, DefaultMaxOutputTokens)
+	}
+}
+
+func TestInputModalities(t *testing.T) {
+	if got := inputModalities("kimi-k2.5"); !reflect.DeepEqual(got, []string{"text", "image"}) {
+		t.Errorf("inputModalities(kimi-k2.5) = %v, want text and image", got)
+	}
+	if got := inputModalities("moonshot-v1-8k-vision-preview"); !reflect.DeepEqual(got, []string{"text", "image"}) {
+		t.Errorf("inputModalities(vision model) = %v, want text and image", got)
+	}
+	if got := inputModalities("moonshot-v1-8k"); got != nil {
+		t.Errorf("inputModalities(text model) = %v, want nil", got)
+	}
+}
+
+func TestThinkingSpec(t *testing.T) {
+	spec := thinkingSpec("kimi-k3")
+	if !reflect.DeepEqual(spec.Levels, []string{provider.ThinkingMax}) {
+		t.Errorf("kimi-k3 thinking levels = %v, want [max]", spec.Levels)
+	}
+	if spec.Default != provider.ThinkingMax || spec.Effort[provider.ThinkingMax] != "max" {
+		t.Errorf("kimi-k3 thinking spec = %+v, want max default and mapping", spec)
+	}
+	if spec := thinkingSpec("kimi-k2.5"); len(spec.Levels) != 0 {
+		t.Errorf("kimi-k2.5 thinking levels = %v, want none", spec.Levels)
+	}
+}


### PR DESCRIPTION
## What

Adds a native Moonshot Kimi provider, built on the shared OpenAI-compatible infrastructure (`openaibase.Register`).

- Endpoint: `https://api.moonshot.cn/v1` (official Moonshot Chat Completions API)
- Credentials: `moonshot_api_key` / `MOONSHOT_API_KEY` env var — independent of the generic OpenAI-compatible provider, so both can be configured side by side
- Live model discovery from `/v1/models`, filtered to `kimi-*` / `moonshot-*` chat models
- Local capability overrides for context window and max output tokens:
  - `kimi-k3`: 1M context, 128K max output, exposed as a thinking model (`reasoning_effort: "max"`)
  - `kimi-k2.7-code(-highspeed)`, `kimi-k2.6`, `kimi-k2.5`: 256K context, text+image input
  - `moonshot-v1-*` (incl. vision variants): 8K/32K/128K context
- `EchoReasoningContent: true` — Kimi thinking/tool-call continuation requires `reasoning_content` echoed back in assistant messages
- K2.x models do not expose the thinking selector (Moonshot uses a separate `thinking` shape there, not `reasoning_effort`)
- Registered in both `cmd/juggler/app/run.go` and the `cmd/juggler-test` mirror

## Tests

- `go test ./cmd/juggler/providers/moonshot ./cmd/juggler/providers/openaibase` — pass
- `go test ./cmd/juggler/providers/...` — pass
- Smoke-tested end to end against the live Moonshot API (model listing + streaming chat completion via the Juggler UI) with a temporary, since-revoked API key

Signed-off-by: rayvapor-cell <rayvapor-cell@users.noreply.github.com>
