### PR TITLE
test(mobile): cover switching strategy (Default → YOLO) from the touch "+" sheet

### DIFF
--- a/web/js-tests/unit-tests/mobile-composer-test.js
+++ b/web/js-tests/unit-tests/mobile-composer-test.js
@@ -14,6 +14,11 @@
  *      existing handlers: the New Thread row dispatches the /thread command and
  *      the Attach image row triggers the hidden file input. Opening the sheet
  *      and picking a row closes it.
+ *   4. The strategy selector — hidden from the inline control row on touch — is
+ *      relocated into that sheet as a working control: bound to the
+ *      conversation's thread it offers every strategy (incl. YOLO), and picking
+ *      one pins it via MessageThread.setStrategy. This is how a phone user
+ *      switches from the Default strategy to YOLO without a desktop.
  *
  * The touch decision normally reads `matchMedia('(hover: none) and
  * (pointer: coarse)')`, which the headless harness cannot drive. So the test
@@ -23,7 +28,9 @@
  */
 
 import { initializeRegistries, assert } from '../utilities/test-helpers.js';
+import strategyRegistry from '../../js/registries/strategy-registry.js';
 import '../../js/components/input-box.js';
+import '../../js/components/strategy-selector.js';
 
 /**
  * Mount an <input-box>, force touch mode, and bind its listeners synchronously.
@@ -203,6 +210,60 @@ export async function runTests() {
     } catch (e) {
       failed++;
       errors.push('actions-sheet-attach: ' + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      /** @type {any} */ (box)._closeActionsSheet?.();
+      container.remove();
+    }
+  }
+
+  // ── Test 5: switch strategy (Default → YOLO) from the "+" sheet ────────────
+  // The relocation only earns its keep if the moved selector still WORKS. Prove
+  // the end a phone user cares about: the sheet's strategy-selector is bound to
+  // the conversation's thread, lists YOLO, and picking it pins YOLO via
+  // MessageThread.setStrategy — the Default→YOLO switch, driven entirely from
+  // the touch composer. (The dropdown's open state is reproduced deterministically
+  // rather than via toggleDropdown's rAF, which the hidden test window can't pump —
+  // the same approach strategy-menu-refresh-test uses.)
+  {
+    const { box, container } = mountTouchComposer();
+    try {
+      if (!strategyRegistry.isInitialized()) await strategyRegistry.init();
+      assert(strategyRegistry.getAllManifests().some((m) => m.id === 'yolo'),
+        'YOLO must be a registered strategy offerable from the mobile sheet');
+
+      await /** @type {any} */ (box)._openActionsSheet();
+      const sheet = /** @type {HTMLElement|null} */ (document.querySelector('.actions-sheet'));
+      assert(!!sheet, 'the "+" button must open an .actions-sheet');
+
+      const selector = /** @type {any} */ (sheet.querySelector('strategy-selector'));
+      assert(!!selector && typeof selector.setMessageThread === 'function',
+        'an upgraded strategy-selector must be relocated into the open sheet');
+
+      // Bind a thread starting on the Default strategy; capture the switch the
+      // selector makes (MessageThread.setStrategy is the real pin path).
+      /** @type {string|null} */
+      let pinned = null;
+      selector.setMessageThread({
+        currentStrategyId: 'default',
+        setStrategy: (/** @type {string} */ id) => { pinned = id; },
+      });
+      assert(selector._currentStrategyId === 'default',
+        'selector must start on the Default strategy before the switch');
+
+      // Open the dropdown's end-state and pick YOLO.
+      selector._dropdownOpen = true;
+      selector.render();
+      const yoloItem = /** @type {HTMLElement|null} */ (
+        selector.querySelector('.strategy-item[data-strategy-id="yolo"]'));
+      assert(!!yoloItem, 'the relocated selector must offer a YOLO item');
+
+      /** @type {HTMLElement} */ (yoloItem).click();
+      assert(pinned === 'yolo',
+        `picking YOLO in the sheet must pin it via setStrategy, got ${JSON.stringify(pinned)}`);
+      passed++;
+    } catch (e) {
+      failed++;
+      errors.push('actions-sheet-strategy-switch: ' + (e instanceof Error ? e.message : String(e)));
     } finally {
       /** @type {any} */ (box)._closeActionsSheet?.();
       container.remove();


### PR DESCRIPTION
## Summary

On a touch device the strategy selector is hidden from the inline composer row and **relocated into the "+" actions sheet** (`input-box._openActionsSheet`), which is how a phone user changes strategy — e.g. switching from the Default strategy to YOLO. The `mobile-composer` unit suite covered the New Thread and Attach-image rows and asserted the selector is *relocated into* the sheet, but nothing verified the relocated selector still **functions** as a control. A regression that left a phone user unable to change strategy would have passed CI.

This adds a regression test that drives the end a phone user actually cares about: it opens the "+" sheet, binds the sheet's `strategy-selector` to a thread on the Default strategy, picks **YOLO**, and asserts it pins via `MessageThread.setStrategy`.

No production code changes — test-only.

## Test plan

- Added **Test 5** to `web/js-tests/unit-tests/mobile-composer-test.js`. The dropdown's open state is reproduced deterministically (mirroring `strategy-menu-refresh-test`) because the hidden test window can't pump `toggleDropdown`'s `requestAnimationFrame`.
- [ ] `make test` passes — *not runnable in my environment* (the browser suite spawns a WebKitGTK `bin/juggler` and needs Go 1.26 + webkit2gtk + xvfb, none present here). Relying on CI's browser suite to exercise it.
- [x] `make lint` (JS + types) passes — `eslint` clean (`--max-warnings 0`) and `tsc --project tooling/jsconfig.json --noEmit` reports 0 errors on the change. `lint-go`/`lint-css` untouched (no Go/CSS changed).
- [ ] Manual verification — see note above; deferred to CI's browser suite.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [x] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [ ] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- Test-only; scoped to the existing `unit:mobile-composer` suite, so it just adds one more checked invariant.
- The assertion intentionally targets the contract that matters to a touch user — *relocated selector → `setStrategy`* — rather than the rAF-driven popup plumbing the harness can't pump. The nested sheet→dropdown handoff at runtime (opening the strategy dropdown dismisses the "+" sheet, re-parenting the selector) is fragile-looking but out of scope here; happy to follow up if you'd like it hardened + covered end-to-end.
