### PR TITLE
Print Direct P2P link and QR code at CLI startup

### DIFF
--- a/cmd/juggler/app/app_phases.go
+++ b/cmd/juggler/app/app_phases.go
@@ -358,7 +358,21 @@ func (a *App) printInteractiveBanner() {
 	}
 	lines = append(lines, "", "Ctrl+C  - Quit")
 	a.server.PrintSessionInfo(lines...)
+	a.printDirectP2PQRCode()
 	if a.server.IsPublicMode() {
 		a.server.PrintLANStatus(true)
 	}
+}
+
+// printDirectP2PQRCode prints the direct peer-to-peer connection link — the
+// local session URL, a direct browser-to-agent connection with no cloud relay
+// in between — together with a compact ASCII QR code for it. This lets the
+// session be opened by scanning from a phone or another device without first
+// opening the connectivity settings tab, and mirrors the QR-code conventions
+// used by PrintLANStatus and the tunnel status box. A registered WAN tunnel,
+// when started, prints its own shareable URL and QR separately (see
+// printTunnelStatus), so this stays focused on the always-present direct link.
+func (a *App) printDirectP2PQRCode() {
+	url := a.serverURL()
+	core.PrintLabeledQRCode("Direct P2P — "+url, url)
 }


### PR DESCRIPTION
## Summary

When Juggler is started from the command line, the interactive startup banner now prints the **direct peer-to-peer connection link** together with a compact **ASCII QR code** for it, right below the existing `JUGGLER IS RUNNING` box. This lets you open the session by scanning from a phone or another device without first opening the connectivity settings tab.

The change is a small, self-contained addition in `printInteractiveBanner`:

- A new `(*App).printDirectP2PQRCode()` helper prints the session URL (a direct browser-to-agent connection, no cloud relay in between) captioned `Direct P2P — <url>`, followed by the QR code.
- It reuses the existing `core.PrintLabeledQRCode` helper and mirrors the QR conventions already used by `PrintLANStatus` and the tunnel status box, so it renders on the same log stream and interleaves cleanly with async engine boot lines.
- A registered WAN tunnel still prints its own shareable URL + QR separately (`printTunnelStatus`), so this stays focused on the always-present direct link and does not duplicate the tunnel output.

## Test plan

- [x] `gofmt` clean on the changed file.
- [x] `go build` / `go vet` of `cmd/juggler/core/...` and `cmd/juggler/server/...` pass under the Go 1.26 toolchain; `go test ./cmd/juggler/core/...` passes.
- [ ] `make test` / `make lint` — the `cmd/juggler/app` package links WebKitGTK (cgo), which I couldn't install in my local sandbox; CI's Linux leg installs `libwebkitgtk-6.0-dev` and exercises the full build/lint/test, so I'm relying on CI for the app-package compile and lint.
- Manual verification: the change is a branch-free terminal-print addition using only pre-existing, verified symbols (`(*App).serverURL()`, `core.PrintLabeledQRCode(label, url string)`); there is no existing unit-test harness around the banner/QR terminal output (the QR helpers and `PrintLANStatus` are likewise untested), and terminal output isn't covered by the browser integration suite.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [ ] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [ ] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- Naming: I captioned the local session URL as "Direct P2P" to match the request this implements; if you'd prefer a different label (e.g. plain "Direct connection", since this URL is a direct browser↔agent link rather than the WebRTC datachannel transport labelled "Peer-to-peer" in `remoteTransportLabel`), that's a one-line change — happy to adjust.
