### PR TITLE
Isolate each conversation in its own git worktree per repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,36 @@ Key invariants:
   maintain it in a reactive observer, not in click handlers.
 - **Window geometry is per-project session state**, stored server-side in the
   session and exposed at `GET/PUT /api/session/window-state`.
+- **One process → one project, but each conversation gets its own worktree of
+  every repo it touches.** The engine is a single, engine-wide tool executor
+  shared by every conversation (side-tab), so two tabs each running an agent
+  would otherwise edit one shared checkout and clobber each other. To isolate
+  them, each **(conversation, repository)** pair gets its own dedicated linked
+  **git worktree** on a `juggler/conv-<id>` branch — because one conversation may
+  span several repos (a folder of services, a repo with nested submodules), each
+  is isolated independently (`cmd/juggler/core/conv_worktree.go` — a
+  channel-based `ConvWorktrees` actor; git plumbing in `worktree.go`). The
+  mechanism is a **path remap**, not a whole-session re-root: a tool call carries
+  a `conversationId` (JS side: every file/search/tree/shell op tags its params
+  via `ContextItem._withConv`, hoisted to the transport by
+  `callOp`/`sendShellStart`), and the Go `PathScope` (`ops/validation.go`)
+  **validates each path in real-project space** (the security boundary is
+  unchanged) then **redirects the resolved path into the conversation's worktree
+  of whichever repo the path belongs to** (`Server.repoRemapper`). Ops
+  (`ops_api.go`), the streaming shell (`websocket_loop.go`), and the git-status
+  card (`git_status_api.go` + `?conversationId=`, scanning each discovered repo
+  in the conversation's checkout) all flow through the remap. Search/tree ops
+  search the worktree but report **project-relative** paths so the agent's reads
+  remap back consistently. Worktrees live under
+  `ConfigDir()/worktrees/<repo>-<hash>/conv-<id>`; a conversation re-adopts its
+  worktrees across restarts, a permanent delete prunes each only if pristine, and
+  a worktree-local `.juggler/.gitignore` keeps metadata out of the diff. A path
+  in no repo under the project (a loose file), an empty convID, a non-git
+  project, or the feature disabled ⇒ the real path unchanged, so nothing changes
+  for those. Toggle with `project.worktree` in config or
+  `--worktree`/`--no-worktree` (test mode forces it off for a stable root).
+  Project-shared state (the memory file) and viewer-only file previews
+  deliberately stay on the base project root.
 
 ## Paths
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ of changes; this project follows semantic versioning.
 
 ## [Unreleased]
 
+- Each conversation now runs in its own git worktree of every repo it touches, so parallel agents don't collide (disable with `--no-worktree`)
+
 ## [0.4.2] - 2026-07-18
 
 - Added moonshot/KIMI, Copilot and llama.cpp providers, refactored and fixed other providers like ollama, codex

--- a/cmd/juggler/app/app.go
+++ b/cmd/juggler/app/app.go
@@ -21,6 +21,8 @@ type appFlags struct {
 	window         bool
 	project        string              // explicit --project value (raw, may be relative)
 	projectSet     bool                // true if --project was passed
+	worktree       bool                // resolved --worktree/--no-worktree value (meaningful only when worktreeSet); toggles per-conversation worktree isolation
+	worktreeSet    bool                // true if --worktree or --no-worktree was passed (overrides project config)
 	hasTerminal    bool                // true if launched with a controlling TTY
 	port           int                 // --port overrides config port (0 = OS-assigned)
 	portSet        bool                // true if --port was passed (allows --port 0 = OS-assigned)

--- a/cmd/juggler/app/app_phases.go
+++ b/cmd/juggler/app/app_phases.go
@@ -29,6 +29,10 @@ import (
 // launch with no --project), the app starts in no-project mode using a
 // default in-memory config; the user picks a project later via the UI.
 // Runs before logging is initialised, so failures go to stderr directly.
+//
+// Per-conversation git worktree isolation is NOT applied here: the project root
+// stays the base repository, and each conversation is re-rooted into its own
+// worktree at tool-execution time by the server (see core.ConvWorktrees).
 func (a *App) loadConfig() error {
 	projectPath, err := a.resolveStartupProject()
 	if err != nil {
@@ -50,6 +54,23 @@ func (a *App) loadConfig() error {
 		return err
 	}
 	a.cfg = cfg
+	return nil
+}
+
+// worktreeOverride translates the launch flags into the server's
+// per-conversation worktree override: test mode forces isolation OFF (the
+// harness needs a deterministic project root); an explicit
+// --worktree/--no-worktree forces the chosen value; otherwise nil lets each
+// project's config decide (default on).
+func (a *App) worktreeOverride() *bool {
+	if a.flags.testMode {
+		off := false
+		return &off
+	}
+	if a.flags.worktreeSet {
+		v := a.flags.worktree
+		return &v
+	}
 	return nil
 }
 
@@ -247,14 +268,15 @@ func (a *App) initServer() error {
 	}
 
 	srv, err := server.New(server.Config{
-		SessionManager: a.session,
-		Host:           a.cfg.Server.Host,
-		Port:           port,
-		DevMode:        a.devModeEnabled(),
-		AssetsFromDisk: assetsFromDisk,
-		ProjectPath:    a.projectPath,
-		BootLock:       a.lock,
-		ExtraRoutes:    a.config.ExtraRoutes,
+		SessionManager:   a.session,
+		Host:             a.cfg.Server.Host,
+		Port:             port,
+		DevMode:          a.devModeEnabled(),
+		AssetsFromDisk:   assetsFromDisk,
+		ProjectPath:      a.projectPath,
+		BootLock:         a.lock,
+		WorktreeOverride: a.worktreeOverride(),
+		ExtraRoutes:      a.config.ExtraRoutes,
 	})
 	if err != nil {
 		jlog.Error("Failed to create server: %v", err)

--- a/cmd/juggler/app/run.go
+++ b/cmd/juggler/app/run.go
@@ -193,6 +193,8 @@ func parseFlags(hasTerminal bool) (appFlags, bool) {
 	killExisting := flag.Bool("kill-existing", false, "If another instance holds the lock, kill it instead of prompting")
 	window := flag.Bool("window", false, "Open a native window instead of printing the server URL")
 	project := flag.String("project", "", "Project folder to open (defaults to cwd in terminal, none in window/app mode)")
+	worktreeOn := flag.Bool("worktree", false, "Force per-conversation git worktree isolation on for this launch, overriding config")
+	worktreeOff := flag.Bool("no-worktree", false, "Disable per-conversation git worktree isolation for this launch, running every conversation in the checkout")
 	port := flag.Int("port", 0, "Override config port (0 = use config value)")
 	testMode := flag.Bool("test", false, "Enable test API routes and print JUGGLER_ADDR to stdout")
 	testIframes := flag.Int("test-iframes", 0, "Test-mode only: open the viewer window at /test-pool?n=N (tiled iframes acting as parallel test lanes) instead of the production UI")
@@ -220,9 +222,13 @@ func parseFlags(hasTerminal bool) (appFlags, bool) {
 	portSet := false
 	publicSet := false
 	logFileSet := false
+	worktreeSet := false
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name == "project" {
 			projectSet = true
+		}
+		if f.Name == "worktree" || f.Name == "no-worktree" {
+			worktreeSet = true
 		}
 		if f.Name == "port" {
 			portSet = true
@@ -257,6 +263,8 @@ func parseFlags(hasTerminal bool) (appFlags, bool) {
 		window:         *window,
 		project:        *project,
 		projectSet:     projectSet,
+		worktree:       *worktreeOn && !*worktreeOff, // --no-worktree wins if both are passed
+		worktreeSet:    worktreeSet,
 		hasTerminal:    hasTerminal,
 		port:           *port,
 		portSet:        portSet,

--- a/cmd/juggler/core/config.go
+++ b/cmd/juggler/core/config.go
@@ -56,6 +56,18 @@ type ContextConfig struct {
 type ProjectConfig struct {
 	Exclude     []string `json:"exclude"`       // Patterns to exclude
 	MaxFileSize int64    `json:"max_file_size"` // Maximum file size to process
+	// Worktree controls per-instance git worktree isolation. When nil (the
+	// default) or true, opening a git repository runs Juggler inside a
+	// dedicated linked worktree on its own branch, so parallel instances don't
+	// collide in the same working tree. Set false to operate directly in the
+	// checkout. Ignored for non-git folders and repositories with no commits.
+	Worktree *bool `json:"worktree,omitempty"`
+}
+
+// WorktreeEnabled reports whether per-instance git worktree isolation is on.
+// It defaults to true, so a config that omits the field opts in.
+func (p ProjectConfig) WorktreeEnabled() bool {
+	return p.Worktree == nil || *p.Worktree
 }
 
 // LoggingConfig tunes log retention and the on/off switch. The log file path is

--- a/cmd/juggler/core/conv_worktree.go
+++ b/cmd/juggler/core/conv_worktree.go
@@ -1,0 +1,288 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Per-conversation, per-repository git worktree isolation (t3code-style).
+//
+// A single Juggler process opens one project, but hosts many conversations
+// (side-tabs), and the engine is a single, engine-wide tool executor shared by
+// all of them. Left alone, two tabs each running an agent edit the same working
+// tree and clobber each other. ConvWorktrees gives every conversation its own
+// dedicated git worktree — and, because one conversation may touch more than one
+// repository (a folder of service repos, a repo with nested submodules), it
+// keys worktrees by (conversation, repository): each repo a conversation touches
+// gets its own worktree.
+//
+// The mechanism is a path remap. Callers validate a path in real-project space
+// (the security boundary is unchanged) and then ask Remap to translate it: the
+// repository the path belongs to is resolved, its (conversation, repo) worktree
+// is created on first use, and the path is rewritten into that worktree. Paths
+// outside any repo under the project (loose files) are returned unchanged, so
+// non-git content stays shared and existing behaviour is preserved.
+//
+// ConvWorktrees is a channel-based actor (the repo lint forbids sync.Mutex): all
+// map access and the "does a worktree exist? if not, create it" check-then-act
+// run on one goroutine, so concurrent ops for one (conversation, repo) never
+// trigger two `git worktree add`s.
+type ConvWorktrees struct {
+	reqCh      chan cwReq
+	quitCh     chan struct{}
+	base       string // real project root (absolute)
+	home       string // worktrees home (…/worktrees)
+	enabled    bool
+	primaryTop string // gitToplevel(base) or "" — the project's own repo (may sit above base)
+}
+
+type cwReqKind int
+
+const (
+	cwRemap    cwReqKind = iota // translate a real path into its (conv,repo) worktree
+	cwRepoRoot                  // worktree path for an explicit (conv, repoTop) — for git status
+	cwRelease                   // conversation deleted — prune all its worktrees
+	cwList                      // snapshot of a conversation's repoTop → worktree
+)
+
+type cwReq struct {
+	kind      cwReqKind
+	convID    string
+	path      string // cwRemap: the real absolute path; cwRepoRoot: the repo toplevel
+	permanent bool
+	resp      chan cwResp
+}
+
+type cwResp struct {
+	path string
+	list map[string]string
+}
+
+// NewConvWorktrees builds the registry for a base project. When enabled is false
+// every Remap is the identity, so callers need no special-casing. The actor
+// goroutine runs until Close.
+func NewConvWorktrees(base, worktreesHome string, enabled bool) *ConvWorktrees {
+	c := &ConvWorktrees{
+		reqCh:   make(chan cwReq),
+		quitCh:  make(chan struct{}),
+		base:    filepath.Clean(base),
+		home:    worktreesHome,
+		enabled: enabled,
+	}
+	if enabled && base != "" {
+		if top, err := gitToplevel(base); err == nil {
+			if abs, aerr := filepath.Abs(top); aerr == nil {
+				top = abs
+			}
+			// Never nest a worktree inside a worktree.
+			if linked, _ := isLinkedWorktree(top); !linked {
+				c.primaryTop = filepath.Clean(top)
+			}
+		}
+	}
+	go c.run()
+	return c
+}
+
+// Remap translates a real, already-validated absolute path into the working
+// path the op should touch: the conversation's dedicated worktree of whichever
+// repository the path belongs to, or the path unchanged when isolation does not
+// apply (disabled, empty convID, or the path is in no eligible repo under the
+// project). Creates the worktree on first use.
+func (c *ConvWorktrees) Remap(convID, absPath string) string {
+	if !c.enabled || convID == "" || absPath == "" {
+		return absPath
+	}
+	r := c.ask(cwReq{kind: cwRemap, convID: convID, path: absPath})
+	if r.path == "" {
+		return absPath
+	}
+	return r.path
+}
+
+// WorktreeForRepo returns the conversation's worktree for an explicit repository
+// toplevel (used by the git-status card to scan each discovered repo in the
+// conversation's checkout), or "" when isolation doesn't apply to it.
+func (c *ConvWorktrees) WorktreeForRepo(convID, repoTop string) string {
+	if !c.enabled || convID == "" || repoTop == "" {
+		return ""
+	}
+	return c.ask(cwReq{kind: cwRepoRoot, convID: convID, path: filepath.Clean(repoTop)}).path
+}
+
+// Release prunes all of a deleted conversation's worktrees. On a permanent
+// delete each is removed only if pristine (no uncommitted changes, no unmerged
+// commits); a bin (soft delete) keeps them so a restore can reuse them.
+func (c *ConvWorktrees) Release(convID string, permanent bool) {
+	if !c.enabled || convID == "" {
+		return
+	}
+	c.ask(cwReq{kind: cwRelease, convID: convID, permanent: permanent})
+}
+
+// Tracked returns a snapshot of repoTop → worktree for a conversation
+// (diagnostics / tests).
+func (c *ConvWorktrees) Tracked(convID string) map[string]string {
+	if !c.enabled {
+		return map[string]string{}
+	}
+	return c.ask(cwReq{kind: cwList, convID: convID}).list
+}
+
+// Close stops the actor goroutine. Worktrees are left on disk (never auto-deleted
+// on shutdown); each is re-adopted by (conversation, repo) on the next launch.
+func (c *ConvWorktrees) Close() {
+	select {
+	case <-c.quitCh:
+	default:
+		close(c.quitCh)
+	}
+}
+
+func (c *ConvWorktrees) ask(r cwReq) cwResp {
+	r.resp = make(chan cwResp, 1)
+	select {
+	case c.reqCh <- r:
+		return <-r.resp
+	case <-c.quitCh:
+		return cwResp{list: map[string]string{}}
+	}
+}
+
+func (c *ConvWorktrees) run() {
+	plans := map[string]*WorktreePlan{} // key: convID\x00repoTop → worktree
+	ineligible := map[string]bool{}     // repoTop → known not a usable repo
+	repoCache := map[string]string{}    // dir → repoTop ("" = none), memoises detection
+	for {
+		select {
+		case <-c.quitCh:
+			return
+		case r := <-c.reqCh:
+			switch r.kind {
+			case cwRemap:
+				r.resp <- cwResp{path: c.remap(plans, ineligible, repoCache, r.convID, r.path)}
+			case cwRepoRoot:
+				plan := c.ensure(plans, ineligible, r.convID, r.path)
+				if plan == nil {
+					r.resp <- cwResp{}
+				} else {
+					r.resp <- cwResp{path: plan.Path}
+				}
+			case cwRelease:
+				c.release(plans, r.convID, r.permanent)
+				r.resp <- cwResp{}
+			case cwList:
+				out := map[string]string{}
+				prefix := r.convID + "\x00"
+				for key, p := range plans {
+					if strings.HasPrefix(key, prefix) {
+						out[strings.TrimPrefix(key, prefix)] = p.Path
+					}
+				}
+				r.resp <- cwResp{list: out}
+			}
+		}
+	}
+}
+
+// remap resolves absPath's repository and rewrites the path into that
+// conversation's worktree of it. Falls back to absPath unchanged on any miss.
+func (c *ConvWorktrees) remap(plans map[string]*WorktreePlan, ineligible map[string]bool, repoCache map[string]string, convID, absPath string) string {
+	absPath = filepath.Clean(absPath)
+	dir := absPath // memoise by directory; a dir's repo is stable
+	repoTop, ok := repoCache[dir]
+	if !ok {
+		repoTop = repoRootWithin(absPath, c.base, c.primaryTop)
+		repoCache[dir] = repoTop
+	}
+	if repoTop == "" {
+		return absPath
+	}
+	plan := c.ensure(plans, ineligible, convID, repoTop)
+	if plan == nil {
+		return absPath
+	}
+	rel, err := filepath.Rel(repoTop, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return absPath
+	}
+	if rel == "." {
+		return plan.Path
+	}
+	return filepath.Join(plan.Path, rel)
+}
+
+// ensure returns the conversation's worktree for repoTop, creating (or adopting)
+// it on first use. Returns nil when repoTop is not a usable git repo (no commit,
+// or a linked worktree) or creation fails; the result is memoised either way.
+func (c *ConvWorktrees) ensure(plans map[string]*WorktreePlan, ineligible map[string]bool, convID, repoTop string) *WorktreePlan {
+	key := convID + "\x00" + repoTop
+	if p, ok := plans[key]; ok {
+		return p
+	}
+	if ineligible[repoTop] {
+		return nil
+	}
+	// A worktree must branch from an existing commit, and we never nest.
+	if _, err := runGit(repoTop, "rev-parse", "--verify", "-q", "HEAD"); err != nil {
+		ineligible[repoTop] = true
+		return nil
+	}
+	if linked, err := isLinkedWorktree(repoTop); err != nil || linked {
+		ineligible[repoTop] = true
+		return nil
+	}
+	baseBranch, _ := runGit(repoTop, "rev-parse", "--abbrev-ref", "HEAD")
+
+	group := filepath.Join(c.home, worktreeGroupName(repoTop))
+	name := convSlot(convID)
+	dir := filepath.Join(group, name)
+	branch := "juggler/" + name
+
+	var plan *WorktreePlan
+	if isRegisteredWorktree(repoTop, dir) {
+		b, _ := runGit(dir, "rev-parse", "--abbrev-ref", "HEAD")
+		plan = &WorktreePlan{Path: dir, Branch: b, BaseRepo: repoTop, BaseBranch: baseBranch, Adopted: true}
+	} else if err := createWorktree(repoTop, dir, branch); err != nil {
+		return nil // transient failure — not memoised as ineligible, so we retry
+	} else {
+		plan = &WorktreePlan{Path: dir, Branch: branch, BaseRepo: repoTop, BaseBranch: baseBranch, Adopted: false}
+	}
+	plans[key] = plan
+	return plan
+}
+
+func (c *ConvWorktrees) release(plans map[string]*WorktreePlan, convID string, permanent bool) {
+	if !permanent {
+		return // a soft delete (bin) keeps every worktree for a possible restore
+	}
+	prefix := convID + "\x00"
+	for key, p := range plans {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		if pruned, _ := PruneWorktreeIfPristine(p); pruned {
+			delete(plans, key)
+		}
+	}
+}
+
+// convSlot is the deterministic, filesystem-/ref-safe worktree name a
+// conversation maps to within each repository group. Stable across restarts (so
+// worktrees are adopted, not duplicated) and unique per conversation id.
+func convSlot(convID string) string {
+	sum := sha256.Sum256([]byte(convID))
+	h := hex.EncodeToString(sum[:])[:12]
+	slug := sanitizeName(convID)
+	if len(slug) > 24 {
+		slug = slug[:24]
+	}
+	return fmt.Sprintf("conv-%s-%s", slug, h)
+}

--- a/cmd/juggler/core/worktree.go
+++ b/cmd/juggler/core/worktree.go
@@ -1,0 +1,246 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package core
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Git worktree helpers shared by the per-conversation worktree registry
+// (conv_worktree.go).
+//
+// Juggler hosts many conversations (side-tabs) in one process, and the engine
+// is a single, engine-wide tool executor shared by all of them. Left alone, two
+// tabs each running an agent edit the same working tree and clobber each other.
+// The fix, modelled on t3code (each agent in its own worktree), gives every
+// conversation a dedicated linked git worktree on its own branch — isolated
+// checkout and index, shared object store and history. This file holds the
+// low-level git plumbing; ConvWorktrees builds the per-conversation policy on
+// top of it.
+
+// WorktreePlan describes a conversation's worktree.
+type WorktreePlan struct {
+	// Path is the absolute worktree working directory.
+	Path string
+	// Branch is the branch checked out in the worktree.
+	Branch string
+	// BaseRepo is the absolute toplevel of the source repository.
+	BaseRepo string
+	// BaseBranch is the branch (or "HEAD" when detached) the worktree was
+	// created from; surfaced to the user so they know how to merge work back.
+	BaseBranch string
+	// Adopted is true when an existing worktree was reused (continuity across
+	// restarts) rather than freshly created.
+	Adopted bool
+}
+
+// PruneWorktreeIfPristine removes a worktree and its branch iff it holds no
+// work — no uncommitted changes and no commits beyond its base branch. It is a
+// safe no-op (returns false, nil) for a detached-HEAD base or any worktree that
+// holds work, so a conversation's edits and commits are never discarded. Used
+// when a conversation is permanently deleted.
+func PruneWorktreeIfPristine(plan *WorktreePlan) (bool, error) {
+	if plan == nil || plan.BaseBranch == "" || plan.BaseBranch == "HEAD" {
+		return false, nil
+	}
+	// Any working-tree change (staged, unstaged, or untracked) means keep.
+	if status, err := runGit(plan.Path, "status", "--porcelain"); err != nil || strings.TrimSpace(status) != "" {
+		return false, nil
+	}
+	// Any commit on the branch not reachable from the base branch means keep.
+	ahead, err := runGit(plan.BaseRepo, "rev-list", "--count", plan.BaseBranch+".."+plan.Branch)
+	if err != nil || strings.TrimSpace(ahead) != "0" {
+		return false, nil
+	}
+	if _, err := runGit(plan.BaseRepo, "worktree", "remove", plan.Path); err != nil {
+		return false, err
+	}
+	// Best-effort branch cleanup; the worktree is already gone.
+	_, _ = runGit(plan.BaseRepo, "branch", "-D", plan.Branch)
+	return true, nil
+}
+
+// createWorktree adds a worktree at dir on branch, reusing the branch if it
+// already exists (e.g. a conversation re-opened after a restart) or creating it
+// off the current HEAD otherwise. On success it drops a self-contained ignore
+// file so Juggler's own .juggler/ metadata never shows up in the worktree's git
+// status or diff.
+func createWorktree(top, dir, branch string) error {
+	var err error
+	if branchExists(top, branch) {
+		_, err = runGit(top, "worktree", "add", dir, branch)
+	} else {
+		_, err = runGit(top, "worktree", "add", "-b", branch, dir, "HEAD")
+	}
+	if err != nil {
+		return err
+	}
+	writeJugglerIgnore(dir)
+	return nil
+}
+
+// writeJugglerIgnore ensures <dir>/.juggler/.gitignore ignores everything under
+// .juggler/, so Juggler's per-project metadata (lock, sessions, config) stays
+// out of the worktree's git status and diff view. It touches only the worktree,
+// never the base repository's ignore rules. Best-effort: on any error Juggler
+// still works, the metadata just isn't hidden.
+func writeJugglerIgnore(dir string) {
+	jdir := filepath.Join(dir, ".juggler")
+	if err := os.MkdirAll(jdir, 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(jdir, ".gitignore"), []byte("*\n"), 0o644)
+}
+
+// worktreeGroupName is a filesystem-safe, per-repository directory name that
+// stays stable across restarts (so a conversation's worktree is re-found and
+// adopted) and unique per repo path (so unrelated repos with the same basename
+// don't collide).
+func worktreeGroupName(top string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(top)))
+	return sanitizeName(filepath.Base(top)) + "-" + hex.EncodeToString(sum[:])[:8]
+}
+
+// sanitizeName reduces s to a conservative filesystem-safe token.
+func sanitizeName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if out == "" {
+		return "repo"
+	}
+	return out
+}
+
+// isRegisteredWorktree reports whether dir is a worktree git currently knows
+// about for the repository at top.
+func isRegisteredWorktree(top, dir string) bool {
+	out, err := runGit(top, "worktree", "list", "--porcelain")
+	if err != nil {
+		return false
+	}
+	want := filepath.Clean(dir)
+	for _, line := range strings.Split(out, "\n") {
+		if rest, ok := strings.CutPrefix(line, "worktree "); ok {
+			if filepath.Clean(strings.TrimSpace(rest)) == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isLinkedWorktree reports whether top is itself a linked worktree (as opposed
+// to the repository's main working tree). A linked worktree's git dir sits
+// under <common>/worktrees/<name>, so it differs from the common dir.
+func isLinkedWorktree(top string) (bool, error) {
+	gitDir, err := runGit(top, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return false, err
+	}
+	commonDir, err := runGit(top, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return false, err
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(top, commonDir)
+	}
+	return filepath.Clean(gitDir) != filepath.Clean(commonDir), nil
+}
+
+// branchExists reports whether refs/heads/<branch> exists in the repo at top.
+func branchExists(top, branch string) bool {
+	_, err := runGit(top, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	return err == nil
+}
+
+// gitToplevel returns the absolute toplevel of the git working tree containing
+// dir, or an error if dir is not inside one.
+func gitToplevel(dir string) (string, error) {
+	return runGit(dir, "rev-parse", "--show-toplevel")
+}
+
+// repoRootWithin returns the toplevel of the git repository that path belongs
+// to, but only when that repository lies within (or is) projectRoot — so a
+// conversation is isolated per repo *under the project*. It walks up from path
+// to projectRoot looking for a .git entry, catching nested repos and submodules
+// (each maps to itself). primaryTop is gitToplevel(projectRoot) — possibly an
+// ancestor of projectRoot when the project folder sits inside a larger repo, or
+// "" when the project isn't in a repo at all — and is the fallback for paths in
+// the project's own repo. Returns "" when path is outside projectRoot or belongs
+// to no eligible repo (e.g. a loose non-git file, which then stays shared).
+func repoRootWithin(path, projectRoot, primaryTop string) string {
+	path = filepath.Clean(path)
+	projectRoot = filepath.Clean(projectRoot)
+	if !isWithinDir(projectRoot, path) {
+		return "" // outside the project — not isolated (see Q2 default)
+	}
+	for cur := path; ; {
+		if hasGitEntry(cur) {
+			return cur
+		}
+		if cur == projectRoot {
+			break
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		cur = parent
+	}
+	if primaryTop != "" && isWithinDir(primaryTop, path) {
+		return primaryTop
+	}
+	return ""
+}
+
+// hasGitEntry reports whether dir contains a `.git` entry (a directory for a
+// normal repo, a file for a submodule or linked worktree) — i.e. dir is a repo
+// toplevel.
+func hasGitEntry(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// isWithinDir reports whether child is parent or lives beneath it.
+func isWithinDir(parent, child string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// runGit runs a git command in dir and returns trimmed stdout, wrapping any
+// failure with the command and stderr for context.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(errb.String())
+		if msg != "" {
+			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, msg)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(out.String()), nil
+}

--- a/cmd/juggler/core/worktree_test.go
+++ b/cmd/juggler/core/worktree_test.go
@@ -1,0 +1,367 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mustGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := runGit(dir, args...)
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", args, dir, err)
+	}
+	return out
+}
+
+// gitInit turns dir into a git repo with a single commit containing one file.
+func gitInit(t *testing.T, dir, file string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "init", "-q")
+	mustGit(t, dir, "config", "user.email", "test@example.com")
+	mustGit(t, dir, "config", "user.name", "Test")
+	mustGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, file), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, dir, "add", ".")
+	mustGit(t, dir, "commit", "-q", "-m", "init")
+}
+
+// gitInitRepo creates a standalone repo (project root IS the repo).
+func gitInitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit(t, dir, "README.md")
+	return dir
+}
+
+func newConv(t *testing.T, base, home string, enabled bool) *ConvWorktrees {
+	t.Helper()
+	c := NewConvWorktrees(base, home, enabled)
+	t.Cleanup(c.Close)
+	return c
+}
+
+func TestConvWorktrees_DisabledIsIdentity(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), false)
+	p := filepath.Join(repo, "README.md")
+	if got := c.Remap("conv-a", p); got != p {
+		t.Errorf("disabled: Remap = %q, want identity %q", got, p)
+	}
+}
+
+func TestConvWorktrees_EmptyConvIsIdentity(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	p := filepath.Join(repo, "README.md")
+	if got := c.Remap("", p); got != p {
+		t.Errorf("empty convID: Remap = %q, want identity %q", got, p)
+	}
+}
+
+func TestConvWorktrees_NonGitPathIsIdentity(t *testing.T) {
+	// A non-git parent that contains no repo at the touched path.
+	base := t.TempDir()
+	loose := filepath.Join(base, "loose.txt")
+	if err := os.WriteFile(loose, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := newConv(t, base, t.TempDir(), true)
+	if got := c.Remap("conv-a", loose); got != loose {
+		t.Errorf("non-git file: Remap = %q, want identity %q", got, loose)
+	}
+}
+
+func TestConvWorktrees_SingleRepoRedirects(t *testing.T) {
+	repo := gitInitRepo(t)
+	home := t.TempDir()
+	c := newConv(t, repo, home, true)
+
+	src := filepath.Join(repo, "README.md")
+	a := c.Remap("conv-a", src)
+	b := c.Remap("conv-b", src)
+
+	if a == src || b == src {
+		t.Fatalf("expected redirect off the real repo, got a=%q b=%q real=%q", a, b, src)
+	}
+	if a == b {
+		t.Fatalf("two conversations must get distinct worktrees, both got %q", a)
+	}
+	for _, p := range []string{a, b} {
+		if !strings.HasPrefix(p, home) {
+			t.Errorf("redirected path %s not under home %s", p, home)
+		}
+		if filepath.Base(p) != "README.md" {
+			t.Errorf("redirected path %s lost the file basename", p)
+		}
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("worktree file %s missing: %v", p, err)
+		}
+	}
+}
+
+func TestConvWorktrees_MultipleReposIndependent(t *testing.T) {
+	// A non-git parent containing two independent repos: one conversation
+	// touching both must get a SEPARATE worktree for each.
+	base := t.TempDir()
+	repoA := filepath.Join(base, "service-a")
+	repoB := filepath.Join(base, "service-b")
+	gitInit(t, repoA, "a.txt")
+	gitInit(t, repoB, "b.txt")
+
+	c := newConv(t, base, t.TempDir(), true)
+	wa := c.Remap("conv-1", filepath.Join(repoA, "a.txt"))
+	wb := c.Remap("conv-1", filepath.Join(repoB, "b.txt"))
+
+	if wa == filepath.Join(repoA, "a.txt") || wb == filepath.Join(repoB, "b.txt") {
+		t.Fatalf("expected both repos redirected, got wa=%q wb=%q", wa, wb)
+	}
+	// Distinct worktrees (different repo groups), and each has the right file.
+	if filepath.Dir(filepath.Dir(wa)) == filepath.Dir(filepath.Dir(wb)) {
+		t.Errorf("two repos shared a worktree group: %q vs %q", wa, wb)
+	}
+	if _, err := os.Stat(wa); err != nil {
+		t.Errorf("repoA worktree file missing: %v", err)
+	}
+	if _, err := os.Stat(wb); err != nil {
+		t.Errorf("repoB worktree file missing: %v", err)
+	}
+	// The two repos' worktrees are distinct checkouts.
+	if filepath.Base(wa) != "a.txt" || filepath.Base(wb) != "b.txt" {
+		t.Errorf("wrong files: wa=%q wb=%q", wa, wb)
+	}
+}
+
+func TestConvWorktrees_NestedRepoIsolatedFromParent(t *testing.T) {
+	// Project root IS a repo, with a nested independent repo inside it. A path
+	// in the nested repo must map to the nested repo's own worktree, not the
+	// parent's.
+	base := gitInitRepo(t)
+	nested := filepath.Join(base, "vendored")
+	gitInit(t, nested, "n.txt")
+
+	c := newConv(t, base, t.TempDir(), true)
+	parentFile := c.Remap("conv-1", filepath.Join(base, "README.md"))
+	nestedFile := c.Remap("conv-1", filepath.Join(nested, "n.txt"))
+
+	if parentFile == filepath.Join(base, "README.md") {
+		t.Fatal("parent repo file was not redirected")
+	}
+	if nestedFile == filepath.Join(nested, "n.txt") {
+		t.Fatal("nested repo file was not redirected")
+	}
+	// Different repo groups → the nested repo has its own worktree.
+	if filepath.Dir(filepath.Dir(parentFile)) == filepath.Dir(filepath.Dir(nestedFile)) {
+		t.Errorf("nested repo shared the parent's worktree group:\n parent=%q\n nested=%q", parentFile, nestedFile)
+	}
+	if _, err := os.Stat(nestedFile); err != nil {
+		t.Errorf("nested worktree file missing: %v", err)
+	}
+}
+
+func TestConvWorktrees_ProjectInsideLargerRepo(t *testing.T) {
+	// Project root is a SUBDIR of a repo (toplevel above the project). The whole
+	// project maps to that repo's worktree.
+	repo := gitInitRepo(t)
+	sub := filepath.Join(repo, "packages", "app")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "x.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", ".")
+	mustGit(t, repo, "commit", "-q", "-m", "add sub")
+
+	c := newConv(t, sub, t.TempDir(), true)
+	got := c.Remap("conv-1", filepath.Join(sub, "x.go"))
+	if got == filepath.Join(sub, "x.go") {
+		t.Fatal("expected redirect into the enclosing repo's worktree")
+	}
+	// The worktree checks out the whole repo, so the file sits at the same
+	// repo-relative location (packages/app/x.go) within it.
+	if !strings.HasSuffix(filepath.ToSlash(got), "packages/app/x.go") {
+		t.Errorf("redirected path %q lost the repo-relative location", got)
+	}
+}
+
+func TestConvWorktrees_RemapIdempotent(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	p := filepath.Join(repo, "README.md")
+	first := c.Remap("conv-x", p)
+	second := c.Remap("conv-x", p)
+	if first != second {
+		t.Errorf("Remap not idempotent: %q vs %q", first, second)
+	}
+}
+
+func TestConvWorktrees_ContinuityAcrossRestart(t *testing.T) {
+	repo := gitInitRepo(t)
+	home := t.TempDir()
+	p := filepath.Join(repo, "README.md")
+
+	c1 := NewConvWorktrees(repo, home, true)
+	first := c1.Remap("conv-persist", p)
+	c1.Close()
+
+	c2 := newConv(t, repo, home, true)
+	again := c2.Remap("conv-persist", p)
+	if again != first {
+		t.Errorf("continuity: got %q, want original %q", again, first)
+	}
+}
+
+func TestConvWorktrees_MetadataIgnoredInStatus(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	wtFile := c.Remap("conv-meta", filepath.Join(repo, "README.md"))
+	wt := filepath.Dir(wtFile)
+
+	if err := os.WriteFile(filepath.Join(wt, ".juggler", "juggler.lock"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if status := mustGit(t, wt, "status", "--porcelain"); strings.TrimSpace(status) != "" {
+		t.Errorf(".juggler metadata leaked into worktree status:\n%s", status)
+	}
+}
+
+func TestConvWorktrees_ReleasePrunesAllPristine(t *testing.T) {
+	base := t.TempDir()
+	repoA := filepath.Join(base, "a")
+	repoB := filepath.Join(base, "b")
+	gitInit(t, repoA, "a.txt")
+	gitInit(t, repoB, "b.txt")
+	c := newConv(t, base, t.TempDir(), true)
+
+	wa := filepath.Dir(c.Remap("conv-1", filepath.Join(repoA, "a.txt")))
+	wb := filepath.Dir(c.Remap("conv-1", filepath.Join(repoB, "b.txt")))
+
+	c.Release("conv-1", true)
+
+	for _, wt := range []string{wa, wb} {
+		if _, err := os.Stat(wt); !os.IsNotExist(err) {
+			t.Errorf("pristine worktree %s still present after permanent delete: %v", wt, err)
+		}
+	}
+}
+
+func TestConvWorktrees_ReleaseKeepsDirty(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	wt := filepath.Dir(c.Remap("conv-dirty", filepath.Join(repo, "README.md")))
+
+	if err := os.WriteFile(filepath.Join(wt, "work.txt"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c.Release("conv-dirty", true)
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree with uncommitted work must be kept, got: %v", err)
+	}
+}
+
+func TestConvWorktrees_ReleaseSoftKeeps(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	wt := filepath.Dir(c.Remap("conv-soft", filepath.Join(repo, "README.md")))
+
+	c.Release("conv-soft", false)
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("soft delete must keep the worktree, got: %v", err)
+	}
+}
+
+func TestConvWorktrees_Tracked(t *testing.T) {
+	base := t.TempDir()
+	repoA := filepath.Join(base, "a")
+	repoB := filepath.Join(base, "b")
+	gitInit(t, repoA, "a.txt")
+	gitInit(t, repoB, "b.txt")
+	c := newConv(t, base, t.TempDir(), true)
+
+	c.Remap("conv-1", filepath.Join(repoA, "a.txt"))
+	c.Remap("conv-1", filepath.Join(repoB, "b.txt"))
+	tracked := c.Tracked("conv-1")
+	if len(tracked) != 2 {
+		t.Errorf("Tracked = %d entries, want 2: %v", len(tracked), tracked)
+	}
+	if _, ok := tracked[filepath.Clean(repoA)]; !ok {
+		t.Errorf("Tracked missing repoA: %v", tracked)
+	}
+}
+
+func TestConvWorktrees_WorktreeForRepo(t *testing.T) {
+	repo := gitInitRepo(t)
+	c := newConv(t, repo, t.TempDir(), true)
+	wt := c.WorktreeForRepo("conv-1", repo)
+	if wt == "" || wt == repo {
+		t.Fatalf("WorktreeForRepo = %q, want a distinct worktree", wt)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "README.md")); err != nil {
+		t.Errorf("worktree checkout missing: %v", err)
+	}
+}
+
+func TestRepoRootWithin(t *testing.T) {
+	base := t.TempDir()
+	repoA := filepath.Join(base, "a")
+	nested := filepath.Join(repoA, "inner")
+	gitInit(t, repoA, "a.txt")
+	gitInit(t, nested, "n.txt")
+
+	cases := []struct {
+		name, path, want string
+	}{
+		{"file in repoA", filepath.Join(repoA, "a.txt"), repoA},
+		{"file in nested repo", filepath.Join(nested, "n.txt"), nested},
+		{"loose file under non-git base", filepath.Join(base, "loose.txt"), ""},
+		{"outside project", filepath.Join(t.TempDir(), "x"), ""},
+	}
+	for _, tc := range cases {
+		got := repoRootWithin(tc.path, base, "")
+		if got != tc.want {
+			t.Errorf("%s: repoRootWithin = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestProjectConfigWorktreeEnabled(t *testing.T) {
+	tru, fls := true, false
+	cases := []struct {
+		name string
+		val  *bool
+		want bool
+	}{
+		{"nil defaults on", nil, true},
+		{"explicit true", &tru, true},
+		{"explicit false", &fls, false},
+	}
+	for _, tc := range cases {
+		if got := (ProjectConfig{Worktree: tc.val}).WorktreeEnabled(); got != tc.want {
+			t.Errorf("%s: WorktreeEnabled() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestWorktreeGroupNameStableAndUnique(t *testing.T) {
+	a := worktreeGroupName("/home/u/projects/myrepo")
+	b := worktreeGroupName("/home/u/projects/myrepo")
+	c := worktreeGroupName("/home/u/other/myrepo")
+	if a != b {
+		t.Errorf("group name not stable: %q vs %q", a, b)
+	}
+	if a == c {
+		t.Errorf("distinct repo paths produced identical group name: %q", a)
+	}
+}

--- a/cmd/juggler/ops/conv_remap_test.go
+++ b/cmd/juggler/ops/conv_remap_test.go
@@ -1,0 +1,105 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package ops
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// prefixRemap redirects any path under real into wt (a stand-in for a
+// conversation's worktree), mirroring what core.ConvWorktrees.Remap does for a
+// single repo without needing git in this unit test.
+func prefixRemap(real, wt string) func(string) string {
+	real = filepath.Clean(real)
+	return func(abs string) string {
+		abs = filepath.Clean(abs)
+		if abs == real {
+			return wt
+		}
+		if rel, err := filepath.Rel(real, abs); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return filepath.Join(wt, rel)
+		}
+		return abs
+	}
+}
+
+// TestRemap_WriteReadGrepStayInWorktree verifies the redirect end to end: a
+// write lands in the worktree (not the real project), a read sees it, and grep
+// reports it with a project-relative path so a follow-up read redirects back to
+// the same worktree file.
+func TestRemap_WriteReadGrepStayInWorktree(t *testing.T) {
+	real := t.TempDir()
+	wt := t.TempDir()
+	scope := NewPathScope(real, nil).WithRemap(prefixRemap(real, wt))
+	fops := NewFileOperations(scope)
+	ctx := context.Background()
+
+	// Write a file by its project-relative path.
+	if _, err := fops.Execute(ctx, "writeFile", map[string]any{
+		"path": "notes/todo.md", "content": "find me: needle\n",
+	}); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+
+	// It must exist in the worktree, and NOT in the real project.
+	if _, err := os.Stat(filepath.Join(wt, "notes", "todo.md")); err != nil {
+		t.Errorf("write did not land in the worktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(real, "notes", "todo.md")); !os.IsNotExist(err) {
+		t.Errorf("write leaked into the real project (isolation broken): %v", err)
+	}
+
+	// A read of the same project-relative path sees the worktree content.
+	res, err := fops.Execute(ctx, "loadFile", map[string]any{"path": "notes/todo.md"})
+	if err != nil {
+		t.Fatalf("loadFile: %v", err)
+	}
+	if m, _ := res.(map[string]any); m["content"] != "find me: needle\n" {
+		t.Errorf("read did not see the worktree write: %v", m["content"])
+	}
+
+	// grep finds it and reports the project-relative path (so the agent's next
+	// read of that path redirects back into the worktree).
+	sops := NewSearchOperations(scope)
+	gres, err := sops.Execute(ctx, "grep", map[string]any{"pattern": "needle"})
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	matches, _ := gres.(map[string]any)["matches"].([]map[string]any)
+	if len(matches) == 0 {
+		t.Fatal("grep found nothing in the worktree")
+	}
+	if got := matches[0]["file"]; got != "notes/todo.md" {
+		t.Errorf("grep reported %q, want project-relative notes/todo.md", got)
+	}
+}
+
+// TestRemap_InProjectWriteNeedsNoApproval guards the security ordering: because
+// AuthorizeOutOfScopeWrite validates the REAL preimage, an ordinary in-project
+// write succeeds without the out-of-root approval flag even though Sanitize
+// redirects the path into a worktree outside the project root.
+func TestRemap_InProjectWriteNeedsNoApproval(t *testing.T) {
+	real := t.TempDir()
+	wt := t.TempDir()
+	scope := NewPathScope(real, nil).WithRemap(prefixRemap(real, wt))
+
+	// In-project path: allowed without approval.
+	if err := scope.AuthorizeOutOfScopeWrite(filepath.Join(wt, "a.txt"), "a.txt", "write", false); err != nil {
+		t.Errorf("in-project write wrongly rejected: %v", err)
+	}
+
+	// Genuinely out-of-project path: still requires approval.
+	outside := filepath.Join(t.TempDir(), "evil.txt")
+	if err := scope.AuthorizeOutOfScopeWrite(outside, outside, "write", false); err == nil {
+		t.Error("out-of-project write was allowed without approval")
+	}
+	if err := scope.AuthorizeOutOfScopeWrite(outside, outside, "write", true); err != nil {
+		t.Errorf("approved out-of-project write rejected: %v", err)
+	}
+}

--- a/cmd/juggler/ops/search_ops.go
+++ b/cmd/juggler/ops/search_ops.go
@@ -97,24 +97,33 @@ func (ops *SearchOperations) grep(ctx context.Context, params map[string]any) (a
 		return nil, fmt.Errorf("invalid regex pattern: %w", err)
 	}
 
-	// Get search path (default to working directory)
-	// Supports glob patterns like "src/**/*.go"
-	searchPath := ""
+	// Resolve the search base. We search the conversation's worktree (execBase)
+	// but report matches relative to the REAL project root, so the agent's reads
+	// of those paths remap back to the same worktree files. realBaseRel is the
+	// real search base relative to the project root (e.g. "" for the whole
+	// project, "repoB" for a nested repo), which is prefixed onto each match's
+	// path-relative-to-execBase to reconstruct the project-relative report path.
+	// Supports glob patterns like "src/**/*.go".
+	execBase := ""
+	realBaseRel := ""
+	globPattern := ""
 	pathIsGlob := false
 	if path, ok := params["path"].(string); ok && path != "" {
 		if containsGlobChars(path) {
-			searchPath = path
+			execBase = ops.scope.BaseDir()
+			globPattern = path
 			pathIsGlob = true
 		} else {
-			// Validate path is within working directory (or an allowed root)
-			pathResult, err := ops.scope.Resolve(path)
+			// Validate path in real-project space, then search its worktree.
+			realResult, err := ops.scope.ResolveReal(path)
 			if err != nil {
 				return nil, fmt.Errorf("invalid path: %w", err)
 			}
-			searchPath = pathResult.AbsPath
+			realBaseRel = relToRoot(ops.scope.Root(), realResult.AbsPath)
+			execBase = ops.scope.Remap(realResult.AbsPath)
 		}
 	} else {
-		searchPath = ops.scope.Root()
+		execBase = ops.scope.BaseDir()
 	}
 
 	// Get max results limit (support both old and new param names)
@@ -142,10 +151,10 @@ func (ops *SearchOperations) grep(ctx context.Context, params map[string]any) (a
 		noIgnore = ni
 	}
 
-	// Load .gitignore patterns (unless noIgnore is true)
+	// Load .gitignore patterns from the worktree we actually search.
 	var gitignorePatterns []string
 	if !noIgnore {
-		gitignorePatterns = loadGitignorePatterns(ops.scope.Root())
+		gitignorePatterns = loadGitignorePatterns(execBase)
 	}
 
 	// Perform search
@@ -154,9 +163,9 @@ func (ops *SearchOperations) grep(ctx context.Context, params map[string]any) (a
 
 	if pathIsGlob {
 		// Use glob to find matching files, then search in each
-		matches, truncated = ops.searchGlobFiles(ctx, searchPath, re, maxResults, gitignorePatterns, noIgnore)
+		matches, truncated = ops.searchGlobFiles(ctx, execBase, realBaseRel, globPattern, re, maxResults, gitignorePatterns, noIgnore)
 	} else {
-		matches, truncated = ops.searchFiles(ctx, searchPath, re, maxResults, filePattern, gitignorePatterns, noIgnore)
+		matches, truncated = ops.searchFiles(ctx, execBase, realBaseRel, re, maxResults, filePattern, gitignorePatterns, noIgnore)
 	}
 	fileCount := countUniqueFiles(matches)
 
@@ -179,13 +188,41 @@ func containsGlobChars(path string) bool {
 	return strings.ContainsAny(path, "*?[")
 }
 
-// searchGlobFiles searches files matching a glob pattern
-func (ops *SearchOperations) searchGlobFiles(ctx context.Context, globPattern string, pattern *regexp.Regexp, maxResults int, gitignorePatterns []string, noIgnore bool) ([]map[string]any, bool) {
+// relToRoot returns abs relative to root as a forward-slashed path, or "" when
+// abs IS root (or the relation can't be computed). Used to record where a search
+// base sits under the real project root so match paths can be reported
+// project-relative.
+func relToRoot(root, abs string) string {
+	rel, err := filepath.Rel(root, abs)
+	if err != nil || rel == "." {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+
+// joinReportPath composes a project-relative report path from a base's
+// project-relative prefix and a file's path within that base (both
+// forward-slashed).
+func joinReportPath(prefix, rel string) string {
+	switch {
+	case prefix == "":
+		return rel
+	case rel == "" || rel == ".":
+		return prefix
+	default:
+		return prefix + "/" + rel
+	}
+}
+
+// searchGlobFiles searches files matching a glob pattern. execBase is the
+// (worktree-redirected) directory to glob within; realBaseRel is that base's
+// path relative to the real project root, prefixed onto reported match paths.
+func (ops *SearchOperations) searchGlobFiles(ctx context.Context, execBase, realBaseRel, globPattern string, pattern *regexp.Regexp, maxResults int, gitignorePatterns []string, noIgnore bool) ([]map[string]any, bool) {
 	matches := make([]map[string]any, 0, maxResults)
 	truncated := false
 
 	// Use doublestar to expand glob pattern
-	files, err := doublestar.Glob(os.DirFS(ops.scope.Root()), globPattern)
+	files, err := doublestar.Glob(os.DirFS(execBase), globPattern)
 	if err != nil {
 		return matches, false
 	}
@@ -195,7 +232,7 @@ func (ops *SearchOperations) searchGlobFiles(ctx context.Context, globPattern st
 		if ctx.Err() != nil {
 			return matches, truncated
 		}
-		absPath := filepath.Join(ops.scope.Root(), relFile)
+		absPath := filepath.Join(execBase, relFile)
 
 		// Skip directories
 		info, err := os.Stat(absPath)
@@ -216,7 +253,7 @@ func (ops *SearchOperations) searchGlobFiles(ctx context.Context, globPattern st
 		}
 
 		// Search within file
-		fileMatches := ops.searchInFile(absPath, ops.scope.Root(), pattern, maxResults-len(matches))
+		fileMatches := ops.searchInFile(absPath, execBase, realBaseRel, pattern, maxResults-len(matches))
 		matches = append(matches, fileMatches...)
 
 		if len(matches) >= maxResults {
@@ -228,13 +265,15 @@ func (ops *SearchOperations) searchGlobFiles(ctx context.Context, globPattern st
 	return matches, truncated
 }
 
-// searchFiles performs native Go file search with early termination
-func (ops *SearchOperations) searchFiles(ctx context.Context, searchPath string, pattern *regexp.Regexp, maxResults int, filePattern string, gitignorePatterns []string, noIgnore bool) ([]map[string]any, bool) {
+// searchFiles performs native Go file search with early termination. execBase is
+// the (worktree-redirected) directory to walk; realBaseRel is that base's path
+// relative to the real project root, prefixed onto reported match paths.
+func (ops *SearchOperations) searchFiles(ctx context.Context, execBase, realBaseRel string, pattern *regexp.Regexp, maxResults int, filePattern string, gitignorePatterns []string, noIgnore bool) ([]map[string]any, bool) {
 	matches := make([]map[string]any, 0, maxResults)
 	truncated := false
 
 	// Walk directory tree
-	err := filepath.WalkDir(searchPath, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(execBase, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil // Skip errors, continue walking
 		}
@@ -246,8 +285,8 @@ func (ops *SearchOperations) searchFiles(ctx context.Context, searchPath string,
 			return ctx.Err()
 		}
 
-		// Get relative path for gitignore matching
-		relPath, _ := filepath.Rel(ops.scope.Root(), path)
+		// Get relative path (to the search base) for gitignore matching
+		relPath, _ := filepath.Rel(execBase, path)
 
 		// Skip directories
 		if d.IsDir() {
@@ -308,7 +347,7 @@ func (ops *SearchOperations) searchFiles(ctx context.Context, searchPath string,
 		}
 
 		// Search within file
-		fileMatches := ops.searchInFile(path, searchPath, pattern, maxResults-len(matches))
+		fileMatches := ops.searchInFile(path, execBase, realBaseRel, pattern, maxResults-len(matches))
 		matches = append(matches, fileMatches...)
 
 		// Early termination when we hit max results
@@ -326,8 +365,12 @@ func (ops *SearchOperations) searchFiles(ctx context.Context, searchPath string,
 	return matches, truncated
 }
 
-// searchInFile searches for pattern within a single file
-func (ops *SearchOperations) searchInFile(filePath, basePath string, pattern *regexp.Regexp, maxMatches int) []map[string]any {
+// searchInFile searches for pattern within a single file. execBase is the
+// directory the file was found under (a worktree when isolation is on);
+// realBaseRel is execBase's location relative to the real project root, so the
+// reported path is project-relative and the agent's subsequent reads of it
+// redirect back to this same worktree file.
+func (ops *SearchOperations) searchInFile(filePath, execBase, realBaseRel string, pattern *regexp.Regexp, maxMatches int) []map[string]any {
 	matches := make([]map[string]any, 0)
 
 	file, err := os.Open(filePath)
@@ -336,14 +379,14 @@ func (ops *SearchOperations) searchInFile(filePath, basePath string, pattern *re
 	}
 	defer file.Close()
 
-	// Get relative path for display (always relative to workingDir, not search path).
-	// EvalSymlinks both sides so macOS's /var ↔ /private/var symlink doesn't
-	// produce a multi-".." rel path (filepath.Rel takes symlinks literally
-	// and a workingDir stored as /var/folders/... vs a filePath surfaced as
-	// /private/var/folders/... would otherwise diverge at the root).
-	// filepath.Rel yields OS separators (\ on Windows); tool results are always
-	// POSIX-style, so normalise back to forward slashes.
-	relPath := filepath.ToSlash(filepathRelEvalSymlinks(ops.scope.Root(), filePath))
+	// Report the match path relative to the REAL project root: the file's path
+	// relative to the (worktree) search base, prefixed with that base's real
+	// project-relative location. EvalSymlinks both sides so macOS's /var ↔
+	// /private/var symlink doesn't produce a multi-".." rel path. filepath.Rel
+	// yields OS separators (\ on Windows); tool results are always POSIX-style,
+	// so normalise back to forward slashes.
+	relInBase := filepath.ToSlash(filepathRelEvalSymlinks(execBase, filePath))
+	relPath := joinReportPath(realBaseRel, relInBase)
 
 	scanner := bufio.NewScanner(file)
 	lineNum := 1
@@ -404,8 +447,9 @@ func (ops *SearchOperations) findSymbol(ctx context.Context, params map[string]a
 	var allResults []map[string]any
 	maxResults := 100
 
-	// Load .gitignore patterns for symbol search
-	gitignorePatterns := loadGitignorePatterns(ops.scope.Root())
+	// Load .gitignore patterns for symbol search from the searched worktree.
+	symbolBase := ops.scope.BaseDir()
+	gitignorePatterns := loadGitignorePatterns(symbolBase)
 
 	for _, patternStr := range patterns {
 		pattern, err := regexp.Compile(patternStr)
@@ -413,7 +457,7 @@ func (ops *SearchOperations) findSymbol(ctx context.Context, params map[string]a
 			continue
 		}
 
-		matches, _ := ops.searchFiles(ctx, ops.scope.Root(), pattern, maxResults-len(allResults), "", gitignorePatterns, false)
+		matches, _ := ops.searchFiles(ctx, symbolBase, "", pattern, maxResults-len(allResults), "", gitignorePatterns, false)
 		allResults = append(allResults, matches...)
 
 		if len(allResults) >= maxResults {

--- a/cmd/juggler/ops/shell_ops.go
+++ b/cmd/juggler/ops/shell_ops.go
@@ -591,7 +591,7 @@ func (ops *ShellOperations) startBackground(params map[string]any) (any, error) 
 		// Build command
 		cmd := newShellCmd(ctx, command)
 		setProcGroup(cmd)
-		cmd.Dir = ops.scope.Root()
+		cmd.Dir = ops.scope.BaseDir()
 
 		updateShellCmd(shellID, cmd)
 
@@ -731,14 +731,16 @@ func (ops *ShellOperations) execute(ctx context.Context, params map[string]any) 
 	// Get timeout from params (defaults to defaultExecTimeoutMs, capped at maxExecTimeoutMs)
 	timeout := timeoutFromParams(params, defaultExecTimeoutMs)
 
-	// Get working directory from params (default: session's project path)
-	workingDir := ops.scope.Root()
+	// Working directory (default: the conversation's worktree of the project).
+	// A given cwd is validated against the REAL project root, then redirected
+	// into the conversation's worktree of whichever repo it lands in.
+	workingDir := ops.scope.BaseDir()
 	if cwd, ok := params["cwd"].(string); ok && cwd != "" {
 		resolved, err := validateCwd(ops.scope.Root(), cwd)
 		if err != nil {
 			return nil, err
 		}
-		workingDir = resolved
+		workingDir = ops.scope.Remap(resolved)
 	}
 
 	// Bound the command by both the caller's context and the timeout. Deriving
@@ -814,7 +816,7 @@ func (ops *ShellOperations) executePythonCode(ctx context.Context, code string, 
 	// Using "-" tells python to read from stdin. On Unix this is python3; on
 	// Windows it is routed through WSL (see newPythonCmd).
 	cmd := newPythonCmd(ctx)
-	cmd.Dir = ops.scope.Root()
+	cmd.Dir = ops.scope.BaseDir()
 	cmd.Stdin = strings.NewReader(code)
 
 	output := newCappedBuffer(outputHeadLimit, outputTailLimit)
@@ -890,7 +892,8 @@ func (ops *ShellOperations) ExecuteStreaming(
 	}
 	timeout := capTimeout(timeoutMs)
 
-	// Working directory, validated to stay within the project root.
+	// Working directory, validated to stay within the real project root, then
+	// redirected into the conversation's worktree of the repo it lands in.
 	workingDir, err := validateCwd(ops.scope.Root(), cwd)
 	if err != nil {
 		output <- ShellStreamChunk{
@@ -900,6 +903,7 @@ func (ops *ShellOperations) ExecuteStreaming(
 		}
 		return
 	}
+	workingDir = ops.scope.Remap(workingDir)
 
 	// Create timeout context
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/cmd/juggler/ops/tree_ops.go
+++ b/cmd/juggler/ops/tree_ops.go
@@ -114,10 +114,13 @@ func (ops *TreeOperations) getTree(params map[string]any) (any, error) {
 		return nil, fmt.Errorf("path does not exist: %w", err)
 	}
 
-	// Load .gitignore patterns (unless showAll is true)
+	// Load .gitignore patterns (unless showAll is true) from the tree base we
+	// actually walk — absPath is already redirected into the conversation's
+	// worktree, so relative-path/gitignore matching must key off it, not the real
+	// project root.
 	var gitignorePatterns []string
 	if !showAll {
-		gitignorePatterns = loadGitignorePatterns(ops.scope.Root())
+		gitignorePatterns = loadGitignorePatterns(absPath)
 	}
 
 	// Build tree with token budget awareness
@@ -130,7 +133,7 @@ func (ops *TreeOperations) getTree(params map[string]any) (any, error) {
 		maxDepth:       depth,
 		showAll:        showAll,
 		gitignore:      gitignorePatterns,
-		workingDir:     ops.scope.Root(),
+		workingDir:     absPath,
 	}
 
 	stats := &treeStats{}

--- a/cmd/juggler/ops/validation.go
+++ b/cmd/juggler/ops/validation.go
@@ -41,6 +41,14 @@ type PathValidationResult struct {
 type PathScope struct {
 	root         string
 	allowedRoots []string
+	// remap, when set, translates an already-validated real absolute path into
+	// the path the op should actually touch — the conversation's dedicated git
+	// worktree of whichever repository the path belongs to (see
+	// core.ConvWorktrees). It is applied to the OUTPUT of Resolve/Sanitize, so
+	// containment and out-of-scope-write authorization still run in real-project
+	// space (the security boundary is unchanged) while execution is redirected
+	// into the worktree. nil ⇒ identity (no per-conversation isolation).
+	remap func(string) string
 }
 
 // NewPathScope builds a PathScope for a working directory widened by an
@@ -55,17 +63,64 @@ func NewPathScope(root string, allowedRoots []string) PathScope {
 	return PathScope{root: root, allowedRoots: roots}
 }
 
-// Root returns the working directory this scope is anchored at.
+// WithRemap returns a copy of the scope whose resolved paths are redirected into
+// per-conversation git worktrees by fn (see the remap field). fn is applied to
+// already-validated real paths; passing nil yields an identity scope.
+func (s PathScope) WithRemap(fn func(string) string) PathScope {
+	s.remap = fn
+	return s
+}
+
+// applyRemap redirects a real absolute path into its worktree when a remap is
+// set, else returns it unchanged.
+func (s PathScope) applyRemap(abs string) string {
+	if s.remap == nil {
+		return abs
+	}
+	return s.remap(abs)
+}
+
+// Root returns the real project working directory this scope is anchored at.
+// It is the security/validation anchor; for the directory an op should actually
+// operate in (redirected into the conversation's worktree) use BaseDir.
 func (s PathScope) Root() string {
 	return s.root
+}
+
+// BaseDir is the working directory an op should default to when no explicit
+// path is given (grep/tree search base, shell cwd) — the real root redirected
+// into the conversation's worktree of the project's own repo, or the real root
+// unchanged when isolation doesn't apply.
+func (s PathScope) BaseDir() string {
+	return s.applyRemap(s.root)
+}
+
+// Remap redirects an already-validated real absolute path into the conversation's
+// worktree. Exposed for ops (shell cwd, git status) that resolve a path against
+// the real root and then need the worktree location to execute in.
+func (s PathScope) Remap(absPath string) string {
+	return s.applyRemap(absPath)
 }
 
 // Resolve validates a requested path for a read/search/tree op, enforcing
 // containment within the working directory OR any allowed root. These ops are
 // NOT approval-gated, so the scope is the policy boundary and must self-enforce
 // containment (including the allowed-roots grant). Write/edit ops use Sanitize
-// instead — see the contrast below.
+// instead — see the contrast below. The returned AbsPath is redirected into the
+// conversation's worktree (containment having been checked in real space).
 func (s PathScope) Resolve(requestedPath string) (*PathValidationResult, error) {
+	result, err := ValidateFilePathWithRoots(s.root, s.allowedRoots, requestedPath)
+	if err == nil && result != nil && result.IsValid {
+		result.AbsPath = s.applyRemap(result.AbsPath)
+	}
+	return result, err
+}
+
+// ResolveReal is Resolve WITHOUT the worktree redirect: it validates containment
+// and returns the real (pre-remap) absolute path. Search/tree ops use it to learn
+// the real location a path maps to, so they can search the redirected worktree
+// yet still report matches relative to the real project root.
+func (s PathScope) ResolveReal(requestedPath string) (*PathValidationResult, error) {
 	return ValidateFilePathWithRoots(s.root, s.allowedRoots, requestedPath)
 }
 
@@ -74,9 +129,15 @@ func (s PathScope) Resolve(requestedPath string) (*PathValidationResult, error) 
 // (the user has already OK'd the write by the time the request lands), so the
 // backend executes faithfully rather than re-imposing a sandbox that would also
 // reject the legitimate out-of-project write the user just approved. Contrast
-// Resolve, which is the gate for the non-approval-gated reads/search/tree.
+// Resolve, which is the gate for the non-approval-gated reads/search/tree. The
+// returned path is redirected into the conversation's worktree; the real path is
+// still what AuthorizeOutOfScopeWrite validates.
 func (s PathScope) Sanitize(requestedPath string) (string, error) {
-	return SanitizeAbsolutePath(s.root, requestedPath)
+	abs, err := SanitizeAbsolutePath(s.root, requestedPath)
+	if err != nil {
+		return "", err
+	}
+	return s.applyRemap(abs), nil
 }
 
 // ResolveUserInitiated resolves a path for a non-approval-gated read/tree op,
@@ -100,13 +161,17 @@ func (s PathScope) ResolveUserInitiated(requestedPath string, userInitiated bool
 	if err != nil {
 		return "", err
 	}
-	rootAbs, err := filepath.Abs(s.root)
-	if err == nil {
-		if real, e := filepath.EvalSymlinks(rootAbs); e == nil {
-			rootAbs = real
-		}
-		if !pathWithinRoot(abs, rootAbs) {
-			jlog.Info("ops: user-initiated out-of-workdir access: %s", abs)
+	// Audit the out-of-workdir case using the REAL path — abs may have been
+	// redirected into a conversation worktree, which is legitimately outside the
+	// project root and must not be logged as an escape.
+	if realAbs, e := SanitizeAbsolutePath(s.root, requestedPath); e == nil {
+		if rootAbs, e2 := filepath.Abs(s.root); e2 == nil {
+			if real, e3 := filepath.EvalSymlinks(rootAbs); e3 == nil {
+				rootAbs = real
+			}
+			if !pathWithinRoot(realAbs, rootAbs) {
+				jlog.Info("ops: user-initiated out-of-workdir access: %s", realAbs)
+			}
 		}
 	}
 	return abs, nil
@@ -371,13 +436,22 @@ func (s PathScope) withinScope(absPath string) bool {
 // Approved out-of-scope writes are logged for the audit trail (mirroring
 // ResolveUserInitiated). kind is "write" or "edit", used only in the message.
 func (s PathScope) AuthorizeOutOfScopeWrite(absPath, requestedPath, kind string, approved bool) error {
-	if s.withinScope(absPath) {
+	// Validate the REAL path, not absPath: Sanitize may have redirected absPath
+	// into a per-conversation worktree (which lives OUTSIDE the project root), so
+	// checking it directly would spuriously demand approval for every ordinary
+	// in-project write. Re-derive the real target from requestedPath so the
+	// boundary is enforced in real-project space, exactly as before worktrees.
+	real, err := SanitizeAbsolutePath(s.root, requestedPath)
+	if err != nil {
+		real = absPath // can't re-derive — fall back to the given path
+	}
+	if s.withinScope(real) {
 		return nil
 	}
 	if !approved {
 		return fmt.Errorf("%s outside project scope requires explicit approval: %q", kind, requestedPath)
 	}
-	jlog.Info("ops: out-of-scope %s approved: %s", kind, absPath)
+	jlog.Info("ops: out-of-scope %s approved: %s", kind, real)
 	return nil
 }
 

--- a/cmd/juggler/server/handlers/git_status_api.go
+++ b/cmd/juggler/server/handlers/git_status_api.go
@@ -23,12 +23,18 @@ import (
 // provider func so a runtime project switch transparently retargets the scan.
 type GitStatusAPI struct {
 	pathProvider func() string
+	// worktreeForRepo resolves a conversation's dedicated worktree for one
+	// repository toplevel, so the status card reports each repo as the visible
+	// conversation's agent is actually editing it (per-repo isolation). Nil ⇒
+	// always scan the real repos.
+	worktreeForRepo func(convID, repoTop string) string
 }
 
 // NewGitStatusAPI creates a new GitStatusAPI. pathProvider must return the
 // current project path on each call ("" when no project is loaded).
-func NewGitStatusAPI(pathProvider func() string) *GitStatusAPI {
-	return &GitStatusAPI{pathProvider: pathProvider}
+// worktreeForRepo resolves a conversation's per-repo worktree (may be nil).
+func NewGitStatusAPI(pathProvider func() string, worktreeForRepo func(convID, repoTop string) string) *GitStatusAPI {
+	return &GitStatusAPI{pathProvider: pathProvider, worktreeForRepo: worktreeForRepo}
 }
 
 // Repo-discovery bounds. The walk is deliberately shallow — a git repo lives at
@@ -61,6 +67,11 @@ type gitStatusResponse struct {
 // simply omitted rather than failing the whole response.
 func (a *GitStatusAPI) HandleGitStatus(w http.ResponseWriter, r *http.Request) {
 	root := a.pathProvider()
+	// Repos are discovered under the REAL project so the layout the user sees is
+	// preserved; each repo's status is then read from the visible conversation's
+	// worktree of THAT repo (per-repo isolation), so a conversation touching
+	// several repos shows each one's own edits.
+	convID := r.URL.Query().Get("conversationId")
 	resp := gitStatusResponse{Root: root, Repos: []gitRepoStatus{}}
 	if root == "" {
 		WriteJSON(w, r, 0, resp)
@@ -71,7 +82,13 @@ func (a *GitStatusAPI) HandleGitStatus(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	for _, dir := range discoverRepos(ctx, root) {
-		changed, staged, ok := repoStatus(ctx, dir)
+		scanDir := dir
+		if convID != "" && a.worktreeForRepo != nil {
+			if wt := a.worktreeForRepo(convID, dir); wt != "" {
+				scanDir = wt
+			}
+		}
+		changed, staged, ok := repoStatus(ctx, scanDir)
 		if !ok {
 			continue
 		}

--- a/cmd/juggler/server/handlers/ops_api.go
+++ b/cmd/juggler/server/handlers/ops_api.go
@@ -23,6 +23,11 @@ type OperationRequest struct {
 	Operation    string         `json:"operation"`
 	Params       map[string]any `json:"params"`
 	AllowedPaths []string       `json:"allowedPaths,omitempty"`
+	// ConversationID identifies the conversation whose tool this is, so the op
+	// runs in that conversation's dedicated git worktree rather than the shared
+	// project root (see core.ConvWorktrees). Empty ⇒ the base project root, so
+	// non-git projects and callers that don't send it behave exactly as before.
+	ConversationID string `json:"conversationId,omitempty"`
 }
 
 // OperationResponse represents the response from a native operation
@@ -36,13 +41,21 @@ type OperationResponse struct {
 // looked up via a provider func so runtime project switches retarget ops.
 type OpsAPI struct {
 	pathProvider func() string
+	// remapperFor returns a path remapper for a conversation: a function that
+	// redirects an already-validated real path into that conversation's
+	// dedicated git worktree of whichever repo the path belongs to (see
+	// core.ConvWorktrees). Returns nil (identity) when isolation doesn't apply.
+	// remapperFor itself may be nil, in which case every op uses the shared
+	// project path unchanged.
+	remapperFor func(convID string) func(string) string
 	// Operation handlers are stateless and recreated per request.
 }
 
-// NewOpsAPI creates a new operations API handler. pathProvider must return
-// the current project path on each call.
-func NewOpsAPI(pathProvider func() string) *OpsAPI {
-	return &OpsAPI{pathProvider: pathProvider}
+// NewOpsAPI creates a new operations API handler. pathProvider must return the
+// current project path on each call. remapperFor supplies a conversation's
+// per-repo worktree remapper (may be nil).
+func NewOpsAPI(pathProvider func() string, remapperFor func(convID string) func(string) string) *OpsAPI {
+	return &OpsAPI{pathProvider: pathProvider, remapperFor: remapperFor}
 }
 
 // HandleOperationCall is the unified entry point for all native operations
@@ -53,17 +66,27 @@ func (api *OpsAPI) HandleOperationCall(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get current project path
+	// Get current project path (empty ⇒ no project loaded).
 	projectPath := api.pathProvider()
 	if projectPath == "" {
 		api.sendError(w, r, "no project loaded", http.StatusConflict)
 		return
 	}
 
+	// Build this conversation's per-repo worktree remapper. The scope stays
+	// rooted at the REAL project (so containment/authorization are unchanged),
+	// and the remapper redirects each resolved path into the conversation's
+	// worktree of the repo it belongs to — so a conversation touching several
+	// repos gets each of them isolated. nil ⇒ no redirect.
+	var remap func(string) string
+	if api.remapperFor != nil && req.ConversationID != "" {
+		remap = api.remapperFor(req.ConversationID)
+	}
+
 	// Route to appropriate operation handler. r.Context() is cancelled when the
 	// client aborts the request (browser aborts the op fetch on Escape), so
 	// long-running ops can stop early instead of running to completion.
-	result, err := api.routeOperation(r.Context(), req.ToolID, req.Operation, req.Params, projectPath, req.AllowedPaths)
+	result, err := api.routeOperation(r.Context(), req.ToolID, req.Operation, req.Params, projectPath, req.AllowedPaths, remap)
 	if err != nil {
 		// Return operation errors as success=false in the response body with HTTP 200
 		// This allows the frontend to handle the error gracefully
@@ -78,7 +101,7 @@ func (api *OpsAPI) HandleOperationCall(w http.ResponseWriter, r *http.Request) {
 // routeOperation routes the operation to the appropriate handler based on tool ID
 // Uses the operations registry for dynamic handler lookup
 // Creates a new handler instance for each request with the session's project path
-func (api *OpsAPI) routeOperation(ctx context.Context, toolID, operation string, params map[string]any, projectPath string, allowedPaths []string) (any, error) {
+func (api *OpsAPI) routeOperation(ctx context.Context, toolID, operation string, params map[string]any, projectPath string, allowedPaths []string, remap func(string) string) (any, error) {
 	// Get factory from registry
 	factory, err := ops.GetGlobal(toolID)
 	if err != nil {
@@ -86,9 +109,10 @@ func (api *OpsAPI) routeOperation(ctx context.Context, toolID, operation string,
 	}
 
 	// Create handler instance bound to the request's path boundary: the
-	// session's project path widened by the caller's allowed-paths grant.
+	// session's project path widened by the caller's allowed-paths grant, with
+	// resolved paths redirected into the conversation's per-repo worktrees.
 	// No caching - operations are stateless.
-	scope := ops.NewPathScope(projectPath, allowedPaths)
+	scope := ops.NewPathScope(projectPath, allowedPaths).WithRemap(remap)
 	handler := factory(scope)
 
 	// Execute the operation

--- a/cmd/juggler/server/handlers/session.go
+++ b/cmd/juggler/server/handlers/session.go
@@ -38,6 +38,10 @@ type SessionAPI struct {
 	// run an LLM-call pipeline.
 	closeConversation   func(conversationID string)
 	resolveDefaultModel func(ctx context.Context) (core.ModelRef, bool)
+	// releaseConvWorktree lets a deleted conversation's dedicated git worktree
+	// be pruned (only when permanent and pristine — see core.ConvWorktrees).
+	// Set by the server; nil is a no-op.
+	releaseConvWorktree func(conversationID string, permanent bool)
 
 	// Test-mode conversation-ownership hooks (all nil in production). In the
 	// multi-lane test pool every lane shares one session, so creates tagged
@@ -48,6 +52,13 @@ type SessionAPI struct {
 	recordConvOwner  func(convID, lane, reason string)
 	checkConvDelete  func(convID, lane string) error
 	releaseConvOwner func(convID string)
+}
+
+// SetConvWorktreeHook wires the per-conversation worktree release hook, called
+// when a conversation is deleted so its dedicated worktree can be pruned if
+// pristine. Nil (the default) disables worktree cleanup.
+func (api *SessionAPI) SetConvWorktreeHook(release func(conversationID string, permanent bool)) {
+	api.releaseConvWorktree = release
 }
 
 // SetConvOwnershipHooks wires the test-mode ownership ledger. Production
@@ -610,6 +621,12 @@ func (api *SessionAPI) HandleDeleteConversation(w http.ResponseWriter, r *http.R
 	if err := api.manager().DeleteConversation(convID, permanent); err != nil {
 		writeError(w, r, http.StatusInternalServerError, err.Error())
 		return
+	}
+
+	// Prune the conversation's dedicated git worktree (permanent + pristine only;
+	// a bin keeps it so a restore can reuse it, and any unmerged work is kept).
+	if api.releaseConvWorktree != nil {
+		api.releaseConvWorktree(convID, permanent)
 	}
 
 	// The conversation is gone; release its ownership so the suite-end leak

--- a/cmd/juggler/server/project_state.go
+++ b/cmd/juggler/server/project_state.go
@@ -13,7 +13,15 @@ import (
 
 	"juggler/cmd/juggler/core"
 	"juggler/internal/jlog"
+	"juggler/internal/userpaths"
 )
+
+// worktreesHome is the directory under which per-repository worktree groups
+// live — beside Juggler's other per-user data, never scattered next to the
+// user's repositories.
+func worktreesHome() string {
+	return filepath.Join(userpaths.ConfigDir(), "worktrees")
+}
 
 // projectState holds the per-project resources that get swapped wholesale
 // when the user opens a different project at runtime. Reads are lock-free
@@ -30,6 +38,75 @@ type projectState struct {
 	// map, and shell cancel map. Project-scoped so a SwitchProject cleanly
 	// cancels in-flight work tied to the old project.
 	viewers *viewerGroup
+
+	// convWorktrees maps each conversation to its dedicated git worktree so
+	// parallel conversations (side-tabs) never share a working tree. Nil in
+	// no-project mode; when worktree isolation is disabled or the project is
+	// not a git repo, every lookup resolves to projectPath (see
+	// core.ConvWorktrees). Project-scoped, so a SwitchProject builds a fresh
+	// one for the new repo and Closes the old.
+	convWorktrees *core.ConvWorktrees
+}
+
+// repoRemapper returns a path remapper for a conversation: a function that
+// redirects an already-validated real path into that conversation's dedicated
+// git worktree of whichever repository the path belongs to (see
+// core.ConvWorktrees.Remap). Returns nil (⇒ no redirect) in no-project mode,
+// when isolation is disabled, or for an empty convID — so ops keep operating on
+// the real project path. This is how every conversation-aware surface (ops, the
+// streaming shell) routes into the right per-(conversation, repo) worktree.
+func (s *Server) repoRemapper(convID string) func(string) string {
+	st := s.projectState.Load()
+	if st == nil || st.convWorktrees == nil || convID == "" {
+		return nil
+	}
+	cw := st.convWorktrees
+	return func(absPath string) string { return cw.Remap(convID, absPath) }
+}
+
+// worktreeForRepo resolves a conversation's worktree for one repository toplevel
+// (used by the git-status card to scan each discovered repo in the
+// conversation's checkout). "" when isolation doesn't apply.
+func (s *Server) worktreeForRepo(convID, repoTop string) string {
+	st := s.projectState.Load()
+	if st == nil || st.convWorktrees == nil {
+		return ""
+	}
+	return st.convWorktrees.WorktreeForRepo(convID, repoTop)
+}
+
+// releaseConvWorktree prunes a deleted conversation's worktrees (permanent +
+// pristine only). Safe no-op in no-project mode or when isolation is disabled.
+func (s *Server) releaseConvWorktree(convID string, permanent bool) {
+	st := s.projectState.Load()
+	if st != nil && st.convWorktrees != nil {
+		st.convWorktrees.Release(convID, permanent)
+	}
+}
+
+// newConvWorktrees builds the per-conversation worktree registry for a project
+// path. It returns nil in no-project mode. Whether isolation is actually active
+// is decided inside core.ConvWorktrees from the enabled flag (worktreeEnabledFor)
+// and whether the path is a git repo.
+func (s *Server) newConvWorktrees(path string) *core.ConvWorktrees {
+	if path == "" {
+		return nil
+	}
+	return core.NewConvWorktrees(path, worktreesHome(), s.worktreeEnabledFor(path))
+}
+
+// worktreeEnabledFor decides whether per-conversation worktree isolation is on
+// for path: an explicit --worktree/--no-worktree launch flag wins; otherwise the
+// project's own config decides, defaulting to on.
+func (s *Server) worktreeEnabledFor(path string) bool {
+	if s.worktreeOverride != nil {
+		return *s.worktreeOverride
+	}
+	cfg, err := core.LoadConfig(path)
+	if err != nil {
+		return true // config unreadable — fall back to the default (on)
+	}
+	return cfg.Project.WorktreeEnabled()
 }
 
 // SessionManager returns the current per-project SessionManager (always non-nil).
@@ -146,6 +223,7 @@ func (s *Server) SwitchProject(newPath string) error {
 		lock:           newLock,
 		fileChangesCh:  make(chan struct{}),
 		viewers:        newViewerGroup(),
+		convWorktrees:  s.newConvWorktrees(newPath),
 	}
 
 	// Atomic swap.
@@ -175,6 +253,9 @@ func (s *Server) SwitchProject(newPath string) error {
 			}
 			if prev.sessionManager != nil {
 				prev.sessionManager.Shutdown()
+			}
+			if prev.convWorktrees != nil {
+				prev.convWorktrees.Close()
 			}
 			if prev.lock != nil {
 				_ = prev.lock.Release()

--- a/cmd/juggler/server/routes.go
+++ b/cmd/juggler/server/routes.go
@@ -73,6 +73,7 @@ func (s *Server) seedProjectState(cfg Config) {
 		sessionManager: cfg.SessionManager,
 		lock:           cfg.BootLock,
 		viewers:        newViewerGroup(),
+		convWorktrees:  s.newConvWorktrees(initialProjectPath),
 	})
 }
 

--- a/cmd/juggler/server/server.go
+++ b/cmd/juggler/server/server.go
@@ -84,14 +84,18 @@ func unmarshalWS[T any](data []byte, label string) (T, bool) {
 
 // Server represents the HTTP server
 type Server struct {
-	router            *mux.Router
-	upgrader          websocket.Upgrader
-	addr              string
-	listener          net.Listener // Bound listener (set after BindPort())
-	devMode           bool         // Inspector / right-click menu + front-end JUGGLER_DEV_MODE (no source checkout needed)
-	assetsFromDisk    bool         // Serve web assets from the on-disk web/ tree with live reload (requires a source checkout)
-	testMode          bool         // Set when test routes are registered; disables network calls in provider listing
-	bootProjectPath   string
+	router          *mux.Router
+	upgrader        websocket.Upgrader
+	addr            string
+	listener        net.Listener // Bound listener (set after BindPort())
+	devMode         bool         // Inspector / right-click menu + front-end JUGGLER_DEV_MODE (no source checkout needed)
+	assetsFromDisk  bool         // Serve web assets from the on-disk web/ tree with live reload (requires a source checkout)
+	testMode        bool         // Set when test routes are registered; disables network calls in provider listing
+	bootProjectPath string
+	// worktreeOverride is the launch-time --worktree/--no-worktree decision:
+	// non-nil forces per-conversation worktree isolation on/off regardless of
+	// project config; nil ⇒ each project's config decides (default on).
+	worktreeOverride  *bool
 	opsAPI            *handlers.OpsAPI
 	completionsAPI    *handlers.CompletionsAPI
 	gitStatusAPI      *handlers.GitStatusAPI
@@ -192,6 +196,10 @@ type Config struct {
 	AssetsFromDisk bool               // If true, serve static files from the on-disk web/ tree with live reload; requires a source checkout
 	ProjectPath    string             // Project root path (for resolving static files when AssetsFromDisk is set)
 	BootLock       *core.InstanceLock // Optional boot-time instance lock; ownership transfers to server.
+	// WorktreeOverride forces per-conversation git worktree isolation on/off
+	// from the launch flags (--worktree/--no-worktree), overriding project
+	// config. Nil ⇒ each project's config decides (default on).
+	WorktreeOverride *bool
 	// ExtraRoutes, if set, is called at the end of setupRoutes with the
 	// server's router, so a wrapping distribution can register additional
 	// HTTP routes without editing this package. Routes registered here pass
@@ -238,6 +246,8 @@ func New(cfg Config) (*Server, error) {
 			cc.CloseConversation(convID)
 		}
 	}, s.resolveDefaultModel)
+	// Prune a deleted conversation's dedicated worktree (permanent + pristine).
+	sessionAPI.SetConvWorktreeHook(s.releaseConvWorktree)
 
 	configAPI, err := handlers.NewConfigAPI(s.ProjectPath, s.RefreshProviders, func() {
 		s.broadcastToAll(map[string]any{"type": "plugin-changed", "path": "config/plugins"})
@@ -275,15 +285,16 @@ func New(cfg Config) (*Server, error) {
 	s.devMode = cfg.DevMode
 	s.assetsFromDisk = cfg.AssetsFromDisk
 	s.bootProjectPath = cfg.ProjectPath
+	s.worktreeOverride = cfg.WorktreeOverride
 	s.extraRoutes = cfg.ExtraRoutes
-	s.opsAPI = handlers.NewOpsAPI(s.ProjectPath)
+	s.opsAPI = handlers.NewOpsAPI(s.ProjectPath, s.repoRemapper)
 	s.completionsAPI = handlers.NewCompletionsAPI(s.ProjectPath, func() ops.PathSearcher {
 		if fw := s.FileWatcher(); fw != nil {
 			return fw.Index()
 		}
 		return nil
 	})
-	s.gitStatusAPI = handlers.NewGitStatusAPI(s.ProjectPath)
+	s.gitStatusAPI = handlers.NewGitStatusAPI(s.ProjectPath, s.worktreeForRepo)
 	s.extensionsAPI = extensionsAPI
 	s.userCommandsAPI = handlers.NewUserCommandsAPI(s.ProjectPath)
 	s.skillsAPI = handlers.NewSkillsAPI(s.ProjectPath)

--- a/cmd/juggler/server/types.go
+++ b/cmd/juggler/server/types.go
@@ -24,11 +24,12 @@ type ModelConfig struct {
 
 // ShellStartRequest represents a request to start a streaming shell command
 type ShellStartRequest struct {
-	Type    string `json:"type"`              // "shell-start"
-	ShellID string `json:"shellId"`           // Unique ID for this shell execution
-	Command string `json:"command"`           // Shell command to execute
-	Cwd     string `json:"cwd,omitempty"`     // Working directory
-	Timeout int    `json:"timeout,omitempty"` // Timeout in milliseconds
+	Type           string `json:"type"`                     // "shell-start"
+	ShellID        string `json:"shellId"`                  // Unique ID for this shell execution
+	Command        string `json:"command"`                  // Shell command to execute
+	Cwd            string `json:"cwd,omitempty"`            // Working directory
+	Timeout        int    `json:"timeout,omitempty"`        // Timeout in milliseconds
+	ConversationID string `json:"conversationId,omitempty"` // Owning conversation, so the shell runs in that conversation's git worktree (see ConvWorktrees). Empty ⇒ base project root.
 }
 
 // ShellCancelRequest represents a request to cancel a running shell command

--- a/cmd/juggler/server/websocket_loop.go
+++ b/cmd/juggler/server/websocket_loop.go
@@ -132,9 +132,13 @@ func (s *Server) processShellRequest(
 		}
 	}()
 
-	// Create shell operations rooted at the project path. The requested cwd is
-	// validated against that root inside ExecuteStreaming.
-	shellOps := ops.NewShellOperations(ops.NewPathScope(s.SessionManager().GetProjectPath(), nil))
+	// Create shell operations rooted at the REAL project path, with paths
+	// redirected into the requesting conversation's per-repo worktrees. The
+	// requested cwd is validated against the real root, then redirected, inside
+	// ExecuteStreaming.
+	shellOps := ops.NewShellOperations(
+		ops.NewPathScope(s.SessionManager().GetProjectPath(), nil).WithRemap(s.repoRemapper(req.ConversationID)),
+	)
 
 	// Create output channel for streaming chunks
 	outputChan := make(chan ops.ShellStreamChunk, 100)

--- a/docs/design/per-conversation-worktrees.md
+++ b/docs/design/per-conversation-worktrees.md
@@ -1,0 +1,100 @@
+# Per-conversation, per-repository git worktrees (t3code-style isolation)
+
+Juggler hosts many conversations (side-tabs) in one process, and the engine is a
+**single, engine-wide tool executor** shared by all of them. Left alone, two
+tabs each running an agent edit the same working tree and clobber each other.
+This gives every conversation its own dedicated git worktree — and, because one
+conversation may touch more than one repository (a folder of service repos, a
+repo with nested submodules), it isolates **each (conversation, repository) pair
+independently**.
+
+This follows the model t3code popularised — bind a thread to a worktree so its
+cwd, terminals, diff view, git status and cleanup all move with it — and extends
+it to the multi-repo case. (t3code itself keys worktrees by *branch + repository*
+and namespaces cross-repo branches as `t3code/pr-<n>/…`; Juggler namespaces per
+conversation as `juggler/conv-<id>`.)
+
+## The constraint this had to solve
+
+A tool call used to reach the Go layer with **no conversation identity**: the
+engine's `callOp` (`web/js/services/ops-api.js`) POSTed
+`{toolId, operation, params, allowedPaths}` to `/api/ops/call`, and the server
+rebuilt the sandbox from one process-global project path. So the core work was
+carrying `conversationId` from the tool down to the op, then redirecting each
+resolved path into the right per-(conversation, repo) worktree.
+
+## How it works — a path remap, not a whole-session re-root
+
+Worktrees live at separate paths (`~/.juggler/worktrees/…`), but the agent
+thinks in the real project layout. Rather than re-root the whole session (which
+can't stay consistent when a conversation spans several repos at different
+locations, and isn't portable), each **individual filesystem access** is
+redirected at the moment it happens:
+
+1. **Identity (JS).** Each tool knows its conversation. `ContextItem._withConv`
+   tags op params with `conversationId`; `callOp` lifts it to a top-level
+   transport field (and strips it from the op params), and the streaming shell
+   passes it via `sendShellStart`. Every file/search/tree/shell tool tags its
+   calls (read, write, edit, grep, glob, tree, bash, batch, explore_code,
+   monitor); the git-status card sends `?conversationId=`. Project-shared state
+   (the memory file) and viewer-only previews deliberately do **not** tag.
+
+2. **Validate real, redirect execution (Go).** `PathScope`
+   (`ops/validation.go`) stays rooted at the **real project** — containment
+   checks and out-of-scope-write authorization run in real-project space, so the
+   security boundary is unchanged. Its new `WithRemap` redirects the *resolved*
+   path into the conversation's worktree of whichever repo it belongs to
+   (`Server.repoRemapper` → `core.ConvWorktrees.Remap`). `file_ops.go` needs
+   **zero** changes; search/tree ops search the worktree but report
+   **project-relative** paths so the agent's subsequent reads remap back to the
+   same worktree files; the shell's cwd is validated against the real root then
+   redirected.
+
+3. **The registry (`core/conv_worktree.go`).** A channel-based actor (the repo
+   lint forbids `sync.Mutex`) keyed by `(convID, repoTop)`:
+   - `Remap(convID, absPath)` — resolve the path's repository (the enclosing repo
+     under the project, catching nested repos/submodules; a loose non-git file
+     stays shared), ensure that repo's worktree on first use, and rewrite the
+     path into it. Idempotent and race-safe: the actor serialises check-then-
+     create so concurrent ops for one (conversation, repo) trigger exactly one
+     `git worktree add`.
+   - `WorktreeForRepo(convID, repoTop)` — used by the git-status card to scan
+     each discovered repo in the conversation's checkout.
+   - `Release(convID, permanent)` — on a permanent delete, prune every worktree
+     of that conversation, each only if pristine (no uncommitted changes, no
+     unmerged commits); a bin (soft delete) keeps them. Never discards work.
+
+## Layout & opt-out
+
+`~/.juggler/worktrees/<repo>-<hash>/conv-<slug>-<hash>` on branch
+`juggler/conv-<slug>-<hash>`, off each repo's HEAD at first touch. A
+worktree-local `.juggler/.gitignore` (`*`) keeps Juggler's metadata out of the
+diff. On by default for git repos; off via `"project": {"worktree": false}`,
+`--no-worktree` (or `--worktree` to force on), and automatically in `--test`
+mode.
+
+## Coverage note
+
+Isolation is per **git repo under the project**. A project-wide operation issued
+from a *non-git* parent folder — a grep across the whole folder, or a shell
+command using absolute cross-repo paths — sees the real tree for the parts that
+belong to no repo; git-tracked work is always isolated. This is the irreducible
+cost of a portable (no symlink/bind-mount) redirect, and could be unioned later.
+
+## Verification
+
+- `core/worktree_test.go` runs against **real git**: single-repo redirect,
+  multiple independent repos in one conversation, nested-repo-isolated-from-
+  parent, project-inside-a-larger-repo, restart adoption, metadata-ignored,
+  prune-if-pristine / keep-dirty / keep-soft-delete, `repoRootWithin` unit cases,
+  config toggle.
+- `ops/conv_remap_test.go` exercises a live remap end-to-end: a write lands in
+  the worktree (not the real project), a read sees it, grep reports it
+  project-relative, and an ordinary in-project write still authorizes without the
+  out-of-root approval flag (the security ordering).
+- Full `core` + `ops` + `server` + `handlers` + `app` suites pass on Go 1.26;
+  `golangci-lint` (incl. the mutex ban) is clean; the JS changes pass `tsc` +
+  `eslint`; the non-browser integration suite passes.
+- The browser JS harness (`TestBrowser`) drives a real GTK4/WebKit window and
+  needs a display that this environment's headless GTK stack can't provide; it's
+  left to CI.

--- a/web/extensions/juggler-core/context-items/batch-context-item.js
+++ b/web/extensions/juggler-core/context-items/batch-context-item.js
@@ -220,7 +220,7 @@ class BatchContextItem extends ContextItem {
             const limit = f.limit || 2000;
             readParams.lineRange = { start: offset, end: offset + limit - 1 };
           }
-          const result = await readFile(/** @type {any} */ (readParams), this.signal, this.getToolAllowedRoots());
+          const result = await readFile(this._withConv(readParams), this.signal, this.getToolAllowedRoots());
           return { file: f.file_path, success: true, result };
         } catch (err) {
           return { file: f.file_path, success: false, error: err instanceof Error ? err.message : String(err) };
@@ -244,7 +244,7 @@ class BatchContextItem extends ContextItem {
           const searchParams = { pattern: s.pattern };
           if (s.path) searchParams.path = s.path;
           if (s.glob) searchParams.include = s.glob;
-          const result = await grep(/** @type {any} */ (searchParams), this.signal, this.getToolAllowedRoots());
+          const result = await grep(this._withConv(searchParams), this.signal, this.getToolAllowedRoots());
           return { pattern: s.pattern, success: true, result, outputMode: s.output_mode || 'files_with_matches' };
         } catch (err) {
           return { pattern: s.pattern, success: false, error: err instanceof Error ? err.message : String(err) };

--- a/web/extensions/juggler-core/context-items/execute-context-item.js
+++ b/web/extensions/juggler-core/context-items/execute-context-item.js
@@ -512,12 +512,12 @@ class ExecuteContextItem extends ContextItem {
     // Handle background execution
     if (runInBackground) {
       const result = await shellBackground(
-        {
+        this._withConv({
           command,
           timeout: params.timeout ? Number(params.timeout) : undefined,
           conv_id: this.conversation.id,
           tool_use_id: this.toolUseId
-        }
+        })
       );
 
       // Return result indicating background execution
@@ -581,7 +581,7 @@ class ExecuteContextItem extends ContextItem {
     // Try streaming execution first, fall back to blocking if WebSocket unavailable
     try {
       const result = await shellStreaming(
-        /** @type {import('../../../js/services/ops-api.js').ShellExecuteParams} */ (params),
+        this._withConv(params),
         (chunk) => {
           // Check for cancellation during streaming
           if (this.signal?.aborted) {
@@ -649,7 +649,7 @@ class ExecuteContextItem extends ContextItem {
 
       // If streaming fails due to WebSocket issues, fall back to blocking execution
       if (streamError instanceof Error && streamError.message.includes('WebSocket')) {
-        const result = await shell(params);
+        const result = await shell(this._withConv(params));
 
         if (this.signal?.aborted) {
           const error = new Error('Command execution cancelled');

--- a/web/extensions/juggler-core/context-items/explore-code-context-item.js
+++ b/web/extensions/juggler-core/context-items/explore-code-context-item.js
@@ -98,7 +98,7 @@ class ExploreCodeContextItem extends ContextItem {
     const code = /** @type {string} */ (params.code);
     const timeoutMs = params.timeout ? Number(params.timeout) : 120000;
 
-    const fs = new ReadOnlyFileSystem(this.getToolAllowedRoots());
+    const fs = new ReadOnlyFileSystem(this.getToolAllowedRoots(), this.getConversationId());
     const { grep, glob } = this._createSearchHelpers();
 
     const result = await runInSandbox(code, {
@@ -120,6 +120,14 @@ class ExploreCodeContextItem extends ContextItem {
     // cancellable along with the rest of the explore_code action.
     const signal = this.signal;
     const allowedPaths = this.getToolAllowedRoots();
+    // Route the sandbox's grep/glob into this conversation's worktree (see
+    // callOp); '' ⇒ base project root.
+    const conversationId = this.getConversationId();
+    /**
+     * @param {Record<string, unknown>} p - Op params
+     * @returns {any} params tagged with conversationId when bound
+     */
+    const withConv = (p) => (conversationId ? { ...p, conversationId } : p);
     return {
       /**
        * Search file contents (ripgrep-style).
@@ -134,7 +142,7 @@ class ExploreCodeContextItem extends ContextItem {
         if (options?.glob) params.include = options.glob;
         if (options?.maxResults) params.maxResults = options.maxResults;
         if (options?.ignoreCase !== undefined) params.ignoreCase = options.ignoreCase;
-        const result = await grepOp(/** @type {any} */ (params), signal, allowedPaths);
+        const result = await grepOp(withConv(params), signal, allowedPaths);
         return result.matches || [];
       },
       /**
@@ -147,7 +155,7 @@ class ExploreCodeContextItem extends ContextItem {
         /** @type {Record<string, unknown>} */
         const params = { pattern };
         if (options?.cwd) params.path = options.cwd;
-        const result = await globOp(/** @type {any} */ (params), signal, allowedPaths);
+        const result = await globOp(withConv(params), signal, allowedPaths);
         const files = result.files || [];
         if (!options?.cwd) return files;
 

--- a/web/extensions/juggler-core/context-items/glob-context-item.js
+++ b/web/extensions/juggler-core/context-items/glob-context-item.js
@@ -104,7 +104,7 @@ class GlobContextItem extends ContextItem {
    */
   async execute(params) {
     const globParams = /** @type {GlobParams} */ (params);
-    return await glob(globParams, this.signal, this.getToolAllowedRoots());
+    return await glob(this._withConv(globParams), this.signal, this.getToolAllowedRoots());
   }
 
   /**

--- a/web/extensions/juggler-core/context-items/monitor-context-item.js
+++ b/web/extensions/juggler-core/context-items/monitor-context-item.js
@@ -179,12 +179,12 @@ class MonitorContextItem extends ContextItem {
       ? MAX_EXEC_TIMEOUT_MS
       : (params.timeout_ms !== undefined ? Math.min(Number(params.timeout_ms), MAX_EXEC_TIMEOUT_MS) : undefined);
 
-    const result = await shellBackground({
+    const result = await shellBackground(this._withConv({
       command,
       timeout: timeoutMs,
       conv_id: this.conversation.id,
       tool_use_id: this.toolUseId
-    });
+    }));
 
     // Ask the worker (via the generic task-output delivery binding) to stream
     // this task's stdout into the conversation. Fire-and-forget: the binding

--- a/web/extensions/juggler-core/context-items/read-file-context-item.js
+++ b/web/extensions/juggler-core/context-items/read-file-context-item.js
@@ -164,7 +164,7 @@ class ReadFileContextItem extends ContextItem {
    */
   async execute(params) {
     const readParams = /** @type {ReadFileParams} */ (params);
-    return await readFile(readParams, this.signal, this.getToolAllowedRoots());
+    return await readFile(this._withConv(readParams), this.signal, this.getToolAllowedRoots());
   }
 
   /**

--- a/web/extensions/juggler-core/context-items/replace-text-context-item.js
+++ b/web/extensions/juggler-core/context-items/replace-text-context-item.js
@@ -150,7 +150,7 @@ class ReplaceTextContextItem extends EditBase {
     let result;
     try {
       result = await editFile(
-        /** @type {import('../../../js/services/ops-api.js').ReadFileEditParams} */ ({ ...params, dryRun: true })
+        this._withConv({ ...params, dryRun: true })
       );
     } catch (err) {
       // If string not found, check if size was the likely cause and give helpful error
@@ -229,7 +229,7 @@ class ReplaceTextContextItem extends EditBase {
 
     // Call typed ops API
     const result = await editFile(
-      /** @type {import('../../../js/services/ops-api.js').ReadFileEditParams} */ (sendParams),
+      this._withConv(sendParams),
       this.signal,
       allowedPaths
     );

--- a/web/extensions/juggler-core/context-items/search-context-item.js
+++ b/web/extensions/juggler-core/context-items/search-context-item.js
@@ -227,7 +227,7 @@ class SearchContextItem extends ContextItem {
     if (params.noIgnore !== undefined) searchParams.noIgnore = params.noIgnore;
 
     // @ts-ignore - params validated above
-    return await grep(searchParams, this.signal, this.getToolAllowedRoots());
+    return await grep(this._withConv(searchParams), this.signal, this.getToolAllowedRoots());
   }
 
   /**

--- a/web/extensions/juggler-core/context-items/write-file-context-item.js
+++ b/web/extensions/juggler-core/context-items/write-file-context-item.js
@@ -135,7 +135,7 @@ class WriteFileContextItem extends EditBase {
     /** @type {string|undefined} */
     let existingContent;
     try {
-      const result = await readFile({ path });
+      const result = await readFile(this._withConv({ path }));
       if (result.exists && result.content !== undefined) {
         existingContent = result.content;
       }
@@ -148,7 +148,7 @@ class WriteFileContextItem extends EditBase {
     // …) before we ask the user to approve. If it can't, fail at validation
     // and skip the approval modal entirely — mirrors replace-text.
     try {
-      await writeFile({ path, content: params.content, dryRun: true });
+      await writeFile(this._withConv({ path, content: params.content, dryRun: true }));
     } catch (err) {
       return {
         valid: false,
@@ -224,7 +224,7 @@ class WriteFileContextItem extends EditBase {
     // backend's defence-in-depth check admits the write.
     const { params: sendParams, allowedPaths } = this._authorizeWrite(writeParams);
     const result = await writeFile(
-      /** @type {import('../../../js/services/ops-api.js').ReadFileWriteParams} */ (sendParams),
+      this._withConv(sendParams),
       this.signal,
       allowedPaths
     );

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -785,6 +785,16 @@ class JugglerApp {
   }
 
   /**
+   * The id of the conversation currently shown, or '' if none. Used by passive,
+   * module-scoped UI (e.g. the git-status card) to scope its query to the
+   * visible conversation's dedicated git worktree.
+   * @returns {string} Visible conversation id, or ''.
+   */
+  getVisibleConversationId() {
+    return this._connectionManager?.getSession?.()?.visibleConversationId || '';
+  }
+
+  /**
    * Cancel the current LLM operation.
    *
    * Vantage-aware. Stopping from a sub-thread's OWN vantage (Escape while

--- a/web/js/components/cards/git-status-card.js
+++ b/web/js/components/cards/git-status-card.js
@@ -172,7 +172,10 @@ export const gitStatusCard = {
       if (inFlight || disposed || !focused()) return;
       inFlight = true;
       try {
-        const data = await api.getGitStatus();
+        // Scope the status to the visible conversation's git worktree so the
+        // card reflects the checkout its agent is editing, not the base repo.
+        const convId = /** @type {any} */ (globalThis).jugglerApp?.getVisibleConversationId?.() || '';
+        const data = await api.getGitStatus(convId);
         if (disposed) return;
         lastSnapshot = {
           root: (data && data.root) || '',

--- a/web/js/services/api.js
+++ b/web/js/services/api.js
@@ -450,10 +450,14 @@ class APIService {
    * Summarise the working tree of every git repo under the project (root repo
    * plus nested subrepos/submodules). Best-effort: repos whose status can't be
    * read are omitted, and an empty repo list means no git repository was found.
+   * @param {string} [conversationId] - Visible conversation, so the summary
+   *   reflects that conversation's dedicated git worktree rather than the base
+   *   project root (per-conversation worktree isolation). Omitted ⇒ base project.
    * @returns {Promise<{root: string, repos: GitRepoStatus[]}>} Project root and per-repo status.
    */
-  async getGitStatus() {
-    return await this.request('/git/status');
+  async getGitStatus(conversationId) {
+    const qs = conversationId ? `?conversationId=${encodeURIComponent(conversationId)}` : '';
+    return await this.request(`/git/status${qs}`);
   }
 
   /**

--- a/web/js/services/fs.js
+++ b/web/js/services/fs.js
@@ -77,10 +77,31 @@ export class FileSystem {
    *   transport arg to the read/search/tree ops (NOT inside params) so this
    *   filesystem can reach user-approved locations outside the project root.
    *   Defaults to project-root-only when omitted.
+   * @param {string} [conversationId] - Owning conversation, tagged onto each
+   *   op so it runs in that conversation's dedicated git worktree. '' ⇒ base.
    */
-  constructor(allowedPaths = []) {
+  constructor(allowedPaths = [], conversationId = '') {
     /** @type {string[]} */
     this._allowedPaths = Array.isArray(allowedPaths) ? allowedPaths : [];
+    /**
+     * Owning conversation, tagged onto each op's params so the backend routes
+     * it into that conversation's dedicated git worktree (per-conversation
+     * isolation). '' ⇒ the base project root.
+     * @type {string}
+     */
+    this._conversationId = conversationId || '';
+  }
+
+  /**
+   * Tag op params with this filesystem's conversation id (see callOp), so the
+   * op runs in the conversation's worktree. No-op when unbound.
+   * @template T
+   * @param {T} params - Op params
+   * @returns {any} params tagged with conversationId when bound
+   * @private
+   */
+  _conv(params) {
+    return this._conversationId ? { ...params, conversationId: this._conversationId } : params;
   }
 
   /**
@@ -99,7 +120,7 @@ export class FileSystem {
         params.lineRange = { start: offset, end: offset + limit - 1 };
       }
     }
-    const result = await readFileLoad(/** @type {any} */ (params), undefined, this._allowedPaths);
+    const result = await readFileLoad(this._conv(params), undefined, this._allowedPaths);
     if (!result.exists) {
       throw new FileSystemError('ENOENT', `no such file or directory: ${filePath}`);
     }
@@ -113,7 +134,7 @@ export class FileSystem {
    * @returns {Promise<void>}
    */
   async writeFile(filePath, content) {
-    await writeFileOp({ path: filePath, content: String(content) });
+    await writeFileOp(this._conv({ path: filePath, content: String(content) }));
   }
 
   /**
@@ -123,7 +144,7 @@ export class FileSystem {
    * @returns {Promise<string[]|Dirent[]>} Directory entry names or Dirent objects
    */
   async readdir(dirPath, options) {
-    const result = await treeExpandDirectory({ path: dirPath }, this._allowedPaths);
+    const result = await treeExpandDirectory(this._conv({ path: dirPath }), this._allowedPaths);
     const items = result.items || [];
     if (options?.withFileTypes) {
       return items.map(i => new Dirent(i.name, i.isDir));
@@ -137,7 +158,7 @@ export class FileSystem {
    * @returns {Promise<Stats>} Stats object with size, mtime, isFile/isDirectory
    */
   async stat(filePath) {
-    const result = await statOp({ path: filePath }, this._allowedPaths);
+    const result = await statOp(this._conv({ path: filePath }), this._allowedPaths);
     if (!result.exists) {
       throw new FileSystemError('ENOENT', `no such file or directory: ${filePath}`);
     }
@@ -150,7 +171,7 @@ export class FileSystem {
    * @returns {Promise<void>}
    */
   async access(filePath) {
-    const result = await statOp({ path: filePath }, this._allowedPaths);
+    const result = await statOp(this._conv({ path: filePath }), this._allowedPaths);
     if (!result.exists) {
       throw new FileSystemError('ENOENT', `no such file or directory: ${filePath}`);
     }
@@ -163,7 +184,7 @@ export class FileSystem {
    * @returns {Promise<void>}
    */
   async mkdir(dirPath, options) {
-    await mkdirOp({ path: dirPath, recursive: options?.recursive ?? false }, this._allowedPaths);
+    await mkdirOp(this._conv({ path: dirPath, recursive: options?.recursive ?? false }), this._allowedPaths);
   }
 }
 

--- a/web/js/services/ops-api.js
+++ b/web/js/services/ops-api.js
@@ -342,14 +342,22 @@ export const MAX_EXEC_TIMEOUT_MS = 1200000;
  * @throws {Error} If operation fails or parameters are invalid
  */
 async function callOp(toolId, operation, params, signal, allowedPaths) {
-  /** @type {{toolId: string, operation: string, params: object, allowedPaths?: string[]}} */
+  // A conversationId injected into params (see ContextItem._withConv) is a
+  // transport field, not an op parameter: lift it to the top level so the
+  // backend can route the op into that conversation's dedicated git worktree,
+  // and strip it from the params the op handler sees.
+  const { conversationId, ...opParams } = /** @type {Record<string, any>} */ (params || {});
+  /** @type {{toolId: string, operation: string, params: object, allowedPaths?: string[], conversationId?: string}} */
   const requestBody = {
     toolId,
     operation,
-    params
+    params: opParams
   };
   if (allowedPaths !== undefined) {
     requestBody.allowedPaths = allowedPaths;
+  }
+  if (conversationId) {
+    requestBody.conversationId = conversationId;
   }
 
   const headers = /** @type {Record<string, string>} */ ({ 'Content-Type': 'application/json' });
@@ -858,12 +866,15 @@ export async function shellExecuteStreaming(params, onOutput, signal) {
       });
     }, timeoutMs);
 
-    // Send shell-start request
+    // Send shell-start request. A conversationId injected into params (see
+    // ContextItem._withConv) routes the shell into that conversation's git
+    // worktree; undefined ⇒ the base project root.
     const sent = wsService.sendShellStart(
       shellId,
       command,
       params.cwd,
-      params.timeout
+      params.timeout,
+      /** @type {any} */ (params).conversationId
     );
 
     if (!sent) {

--- a/web/js/services/websocket.js
+++ b/web/js/services/websocket.js
@@ -625,9 +625,11 @@ class WebSocketService {
    * @param {string} command - Shell command to execute
    * @param {string} [cwd] - Working directory (optional)
    * @param {number} [timeout] - Timeout in milliseconds (optional)
+   * @param {string} [conversationId] - Owning conversation, so the shell runs in
+   *   that conversation's git worktree (empty/omitted ⇒ base project root)
    * @returns {boolean} True if sent successfully
    */
-  sendShellStart(shellId, command, cwd, timeout) {
+  sendShellStart(shellId, command, cwd, timeout, conversationId) {
     if (!this.connected || !this._transport) {
       console.error(`[ESSENTIAL] [WebSocket] Not connected, cannot send shell-start`);
       return false;
@@ -639,7 +641,8 @@ class WebSocketService {
         shellId,
         command,
         cwd,
-        timeout
+        timeout,
+        conversationId
       });
       this._sendTransport(payload);
       return true;

--- a/web/sdk/context-item.js
+++ b/web/sdk/context-item.js
@@ -341,6 +341,36 @@ class ContextItem {
     return this.messageThread?.getExplicitAllowedPaths?.() || [];
   }
 
+  /**
+   * The conversation this tool belongs to, passed to file/search/tree/shell
+   * backend ops so they run inside that conversation's dedicated git worktree
+   * (per-conversation isolation — see core.ConvWorktrees) rather than the shared
+   * project root. Returns '' when unbound, which the backend treats as "use the
+   * base project path", so non-git projects and unbound calls behave as before.
+   * Deliberately NOT used for project-shared state (e.g. the memory file) or
+   * viewer-only file previews, which must resolve against the base project.
+   * @returns {string} Conversation id, or '' when unbound.
+   */
+  getConversationId() {
+    return this.conversation?.id || this.messageThread?.conversationId || '';
+  }
+
+  /**
+   * Tag an op's params with this tool's conversation id so the backend routes
+   * the op into that conversation's dedicated git worktree. callOp (HTTP ops)
+   * and shellExecuteStreaming (the streaming shell) both lift `conversationId`
+   * off the params to the transport and strip it from the op params. A no-op
+   * (returns params unchanged) when unbound, so nothing is added for non-git
+   * projects or contexts without a conversation.
+   * @template T
+   * @param {T} params - Op parameters
+   * @returns {any} params, tagged with conversationId when bound
+   */
+  _withConv(params) {
+    const cid = this.getConversationId();
+    return cid ? { ...params, conversationId: cid } : params;
+  }
+
   // ============================================================================
   // TITLES AND SUMMARIES
   // ============================================================================


### PR DESCRIPTION
## What & why

Juggler hosts many conversations (side-tabs) in one process, and the engine is a **single, engine-wide tool executor** shared by all of them. Two tabs each running an agent therefore edit **one shared working tree** and clobber each other's files and index.

This gives **every conversation its own git worktree** — and because one conversation may touch **more than one git repository** (a folder of service repos, a repo with nested submodules), it isolates **each `(conversation, repository)` pair independently**. A path in no repo under the project, an empty conversation id, a non-git project, or the feature disabled all resolve to the real path unchanged, so nothing changes for those cases.

This follows the model [t3code](https://github.com/pingdotgg/t3code) popularised — bind a thread to a worktree so its cwd, terminals, diff view, git status and cleanup all move with it — and extends it to the multi-repo case. (t3code's `GitManager` keys worktrees by *branch + repository* and namespaces cross-repo branches `t3code/pr-<n>/…`; Juggler namespaces per conversation `juggler/conv-<id>`.)

> Supersedes the earlier per-*instance* draft: per-conversation is strictly stronger (it isolates side-tabs within one instance too), and this revision further isolates **per repo** within a conversation. Squashed to one commit.

## The core problem it solves

A tool call used to reach the Go layer with **no conversation identity**: `callOp` POSTed `{toolId, operation, params, allowedPaths}` and the server rebuilt the sandbox from one process-global project path. The work was carrying `conversationId` down to the op and redirecting each resolved path into the right per-(conversation, repo) worktree.

## How it works — a path remap, not a whole-session re-root

Worktrees live at separate paths (`~/.juggler/worktrees/…`) but the agent thinks in the real project layout, and a conversation may span several repos at different locations. So instead of re-rooting the session, each **individual filesystem access** is redirected as it happens:

- **Identity (JS).** `ContextItem._withConv` tags op params with `conversationId`; `callOp` lifts it to a top-level transport field (stripping it from op params), and the streaming shell passes it via `sendShellStart`. Every file/search/tree/shell tool tags its calls (read, write, edit, grep, glob, tree, bash, batch, explore_code, monitor); the git-status card sends `?conversationId=`. Memory (project-shared) and viewer-only previews deliberately stay on the base root.
- **Validate real, redirect execution (Go).** `PathScope` (`ops/validation.go`) stays rooted at the **real project** — containment and out-of-scope-write authorization run in real-project space, so **the security boundary is unchanged** — and its new `WithRemap` redirects the *resolved* path into the conversation's worktree of whichever repo it belongs to (`Server.repoRemapper` → `core.ConvWorktrees.Remap`). `file_ops.go` needs **zero** changes. Search/tree ops search the worktree but report **project-relative** paths so the agent's reads remap back consistently; the shell cwd is validated against the real root, then redirected.
- **Registry (`core/conv_worktree.go`).** A channel-based actor (the repo lint forbids `sync.Mutex`) keyed by `(convID, repoTop)`: `Remap` resolves the path's enclosing repo (catching nested repos/submodules; a loose non-git file stays shared), ensures that repo's worktree on first use (race-safe: one `git worktree add` per pair), and rewrites the path. `Release(convID, permanent)` prunes **every** worktree of a permanently-deleted conversation, each only if pristine — never discards work.

## Layout & opt-out

`~/.juggler/worktrees/<repo>-<hash>/conv-<id>` on `juggler/conv-<id>`, off each repo's HEAD at first touch. A worktree-local `.juggler/.gitignore` keeps metadata out of the diff. On by default for git repos; off via `"project": {"worktree": false}`, `--no-worktree` (or `--worktree`), and automatically in `--test` mode.

## Coverage note

Isolation is per **git repo under the project**. A project-wide op from a *non-git* parent folder (grep over the whole folder, or a shell command using absolute cross-repo paths) sees the real tree for the parts belonging to no repo; git-tracked work is always isolated. That's the irreducible cost of a portable (no symlink/bind-mount) redirect, and could be unioned later.

## Files

- `cmd/juggler/core/conv_worktree.go` (registry) + `worktree.go` (git plumbing) + `worktree_test.go`
- `cmd/juggler/ops/{validation,search_ops,tree_ops,shell_ops}.go` — `PathScope.WithRemap`, worktree-aware search/tree/shell + `conv_remap_test.go`
- `cmd/juggler/server/{project_state,server,routes,types,websocket_loop}.go` + `handlers/{ops_api,git_status_api,session}.go`
- `cmd/juggler/{app,core/config}` — flags / config toggle
- `web/…` — `_withConv` seam + per-tool threading + git-status card
- `docs/design/per-conversation-worktrees.md`, `AGENTS.md`, `CHANGELOG.md`

## Testing

- `core/worktree_test.go` (**real git**): single-repo redirect, **multiple independent repos in one conversation**, **nested-repo-isolated-from-parent**, project-inside-a-larger-repo, restart adoption, metadata-ignored, prune-if-pristine / keep-dirty / keep-soft-delete, config toggle.
- `ops/conv_remap_test.go`: live remap end-to-end — a write lands in the worktree (not the real project), a read sees it, grep reports it project-relative, and an ordinary in-project write still authorizes without the out-of-root flag (the security ordering).
- Full `core` + `ops` + `server` + `handlers` + `app` suites pass on **Go 1.26**; **`golangci-lint` clean** (incl. the mutex ban); JS `tsc` + `eslint` clean; non-browser integration passes. I installed Go 1.26 and the WebKitGTK dev libs locally to run all of this.
- Not runnable here: the browser JS harness (`TestBrowser`) drives a real GTK4/WebKit window and needs a display this headless box's GTK stack can't provide — left to CI.

## Open questions for maintainers

Defaults I picked and am happy to change: worktree **location** (`~/.juggler/worktrees` vs sibling), **lazy** ensure-on-first-touch vs eager, **prune-if-pristine** vs keep-always on delete, and whether to also isolate **non-git** loose files (currently shared).
