### PR TITLE
AI-generate conversation names from the opening exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ of changes; this project follows semantic versioning.
 
 ## [Unreleased]
 
+- Conversations are now auto-named by AI from their opening exchange (the first prompt + first reply), replacing the "Task N" placeholder — the naming runs as an isolated one-shot completion that never touches the live conversation's provider session, and never overwrites a title you set yourself
+- Increased the maximum conversation/tab name length (48 → 72 characters)
+
 ## [0.4.2] - 2026-07-18
 
 - Added moonshot/KIMI, Copilot and llama.cpp providers, refactored and fixed other providers like ollama, codex

--- a/cmd/juggler/core/convdir.go
+++ b/cmd/juggler/core/convdir.go
@@ -56,12 +56,25 @@ func GenerateConvID() string {
 // convDirSeparator separates the sanitized name from the id in folder names.
 const convDirSeparator = "--"
 
-// SanitizedNameMaxRunes caps the sanitized name length to leave headroom
-// under the 255-byte filename limits on most filesystems even when
-// characters expand to 4-byte UTF-8 sequences. The full folder name is
-// "<name><sep><conv_<9-char id>>" so the cap also keeps Windows MAX_PATH
-// happy for reasonable project paths.
-const SanitizedNameMaxRunes = 50
+// SanitizedNameMaxRunes caps the sanitized name length in RUNES — the
+// user-facing "how many characters fit in a tab name" limit. It is the
+// filesystem-side counterpart of the UI's MAX_CONVERSATION_NAME_LENGTH
+// (web/js/utils/constants.js), and is kept a couple of runes ABOVE it so a
+// name the UI accepts is never silently truncated when the folder is written.
+//
+// Runes alone don't bound filesystem safety, though: a rune can expand to a
+// 4-byte UTF-8 sequence (emoji), so a 74-rune name could reach ~296 bytes and
+// blow the 255-byte filename limit ext4/APFS enforce. sanitizedNameMaxBytes is
+// the second, independent clamp that guarantees the full folder name
+// "<name><sep><conv_id>" stays comfortably under 255 bytes even for an
+// all-emoji name. Both caps apply; whichever binds first wins.
+const SanitizedNameMaxRunes = 74
+
+// sanitizedNameMaxBytes caps the sanitized name's UTF-8 byte length. With the
+// "--<conv_id>" suffix (~16 bytes) this keeps the whole folder name well under
+// the 255-byte filename limit on every supported filesystem, and keeps Windows
+// MAX_PATH happy for reasonable project paths. See SanitizedNameMaxRunes.
+const sanitizedNameMaxBytes = 200
 
 var (
 	// forbiddenCharRe matches characters that are unsafe in filenames on at
@@ -116,10 +129,17 @@ func SanitizeName(raw string) string {
 		s += "_"
 	}
 
-	// Truncate to rune cap. Trim trailing whitespace/dots again in case the
-	// truncation landed on a problematic character.
-	if rs := []rune(s); len(rs) > SanitizedNameMaxRunes {
-		s = strings.TrimRight(string(rs[:SanitizedNameMaxRunes]), ". ")
+	// Truncate to the rune cap first (display length), then to the byte cap
+	// (filesystem safety) on a rune boundary. Trim trailing whitespace/dots
+	// again in case the truncation landed on a problematic character.
+	if rs := []rune(s); len(rs) > SanitizedNameMaxRunes || len(s) > sanitizedNameMaxBytes {
+		if len(rs) > SanitizedNameMaxRunes {
+			rs = rs[:SanitizedNameMaxRunes]
+		}
+		for len(rs) > 0 && len(string(rs)) > sanitizedNameMaxBytes {
+			rs = rs[:len(rs)-1]
+		}
+		s = strings.TrimRight(string(rs), ". ")
 		if s == "" {
 			return "Untitled"
 		}

--- a/cmd/juggler/core/convdir_test.go
+++ b/cmd/juggler/core/convdir_test.go
@@ -1,0 +1,54 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeNameRuneCap(t *testing.T) {
+	// An ASCII name longer than the rune cap is truncated to exactly the cap.
+	in := strings.Repeat("a", SanitizedNameMaxRunes+25)
+	got := SanitizeName(in)
+	if n := len([]rune(got)); n != SanitizedNameMaxRunes {
+		t.Fatalf("rune length = %d, want %d", n, SanitizedNameMaxRunes)
+	}
+}
+
+func TestSanitizeNameByteCapWithMultibyte(t *testing.T) {
+	// An all-emoji name (4 bytes/rune) must be clamped by BYTES so the folder
+	// name stays under filesystem limits, even though its rune count is under
+	// the rune cap.
+	in := strings.Repeat("😀", SanitizedNameMaxRunes) // 4 bytes each
+	got := SanitizeName(in)
+
+	if len(got) > sanitizedNameMaxBytes {
+		t.Fatalf("byte length = %d, want <= %d", len(got), sanitizedNameMaxBytes)
+	}
+	// Must remain valid UTF-8 (no rune split mid-truncation).
+	if strings.ContainsRune(got, '\uFFFD') {
+		t.Fatalf("result contains replacement char (rune split): %q", got)
+	}
+	// The whole folder name must be comfortably under the 255-byte filename cap.
+	folder := BuildDirName(got, "conv_abcdefghi")
+	if len(folder) > 255 {
+		t.Fatalf("folder name %d bytes, exceeds 255", len(folder))
+	}
+}
+
+func TestSanitizeNameShortNameUnchanged(t *testing.T) {
+	// A normal AI-generated title well under both caps is preserved verbatim.
+	in := "Refactor Auth Middleware"
+	if got := SanitizeName(in); got != in {
+		t.Fatalf("SanitizeName(%q) = %q, want unchanged", in, got)
+	}
+}
+
+func TestSanitizeNameEmptyIsUntitled(t *testing.T) {
+	if got := SanitizeName("   "); got != "Untitled" {
+		t.Fatalf("SanitizeName(whitespace) = %q, want Untitled", got)
+	}
+}

--- a/cmd/juggler/server/name_gen.go
+++ b/cmd/juggler/server/name_gen.go
@@ -1,0 +1,222 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"juggler/cmd/juggler/core"
+	"juggler/cmd/juggler/osactivity"
+	provider "juggler/cmd/juggler/providers/registry"
+	"juggler/cmd/juggler/server/handlers"
+	"juggler/internal/jlog"
+)
+
+// Auto-naming: turn a conversation's opening exchange into a short, human
+// readable tab title using the conversation's own model — the same idea as
+// t3.chat / t3code naming a thread from its first message. The frontend
+// (web/js/services/auto-namer.js) detects the first completed turn, POSTs the
+// opening prompt + reply here, and applies the returned title through the
+// normal rename path only if the user hasn't renamed the tab themselves.
+
+// nameGenSystemPrompt instructs the model to emit ONLY a short title. The
+// output is sanitized and truncated afterwards regardless, so a misbehaving
+// model degrades to a clipped title rather than a bad tab name.
+const nameGenSystemPrompt = `You generate a short, descriptive title for a coding-assistant conversation, given the user's first message and the assistant's first reply.
+
+Rules:
+- Reply with ONLY the title. No quotes, no trailing punctuation, no "Title:" prefix, no explanation.
+- 2 to 6 words, Title Case.
+- Name the concrete task or topic. Prefer specifics (the file, tool, technology, or goal) over generic words like "Help", "Question", or "Request".
+- Never include the words "conversation", "chat", "thread", or "task".`
+
+// nameGenTimeout bounds the isolated naming turn. Auto-naming is best-effort
+// and must never wedge; if the model is slow the frontend simply keeps the
+// default "Task N" name.
+const nameGenTimeout = 30 * time.Second
+
+// nameGenInputCap bounds how much of the prompt / reply we forward, keeping the
+// naming turn cheap regardless of how long the opening exchange was. The
+// frontend also trims, so this is a backstop.
+const nameGenInputCap = 4000
+
+// generateNameRequest is the POST body for the auto-naming endpoint.
+type generateNameRequest struct {
+	Model    ModelConfig `json:"model"`
+	Prompt   string      `json:"prompt"`
+	Response string      `json:"response"`
+}
+
+// handleGenerateConversationName turns the opening exchange into a suggested
+// title. It is a pure "text → title" endpoint: it never renames the
+// conversation itself — the frontend owns the "only if still auto-named"
+// decision and applies the result through the existing rename API. Lives in the
+// server package (not handlers) because it needs provider access.
+func (s *Server) handleGenerateConversationName(w http.ResponseWriter, r *http.Request) {
+	convID, ok := handlers.ConvIDFromVars(w, r)
+	if !ok {
+		return
+	}
+
+	var req generateNameRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		handlers.WriteJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		handlers.WriteJSON(w, r, http.StatusBadRequest, map[string]string{"error": "prompt is required"})
+		return
+	}
+	if req.Model.Provider == "" || req.Model.Model == "" {
+		handlers.WriteJSON(w, r, http.StatusBadRequest, map[string]string{"error": "model (provider + model) is required"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), nameGenTimeout)
+	defer cancel()
+
+	name, err := s.generateConversationName(ctx, convID, req.Model, req.Prompt, req.Response)
+	if err != nil {
+		jlog.Debug("generate-name: conv=%s failed: %v", convID, err)
+		handlers.WriteJSON(w, r, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	handlers.WriteJSON(w, r, http.StatusOK, map[string]string{"name": name})
+}
+
+// generateConversationName runs a single isolated LLM completion that turns the
+// opening exchange into a short title.
+//
+// Isolation is the whole point: it opens its OWN provider handle under a
+// synthetic conversation id, entirely outside the server's conversationCache
+// and the live conversation's provider-side state, and Closes it on return. A
+// stateful provider (claudecode) therefore spins a throwaway CLI for the naming
+// turn instead of injecting a spurious "name this" turn into the real session —
+// so auto-naming can never perturb, resume, or corrupt the user's conversation.
+func (s *Server) generateConversationName(ctx context.Context, convID string, model ModelConfig, prompt, response string) (string, error) {
+	creds, err := core.NewCredentialsStore()
+	if err != nil {
+		return "", fmt.Errorf("credentials: %w", err)
+	}
+	credential, err := creds.GetProviderCredential(model.Provider)
+	if err != nil {
+		return "", fmt.Errorf("credentials: %w", err)
+	}
+
+	prov, err := provider.InitializeProvider(model.Provider, provider.Config{
+		APIKey:      credential.APIKey,
+		BearerToken: credential.BearerToken,
+		Headers:     credential.Headers,
+		Model:       model.Model,
+	})
+	if err != nil {
+		return "", fmt.Errorf("initialize provider %q: %w", model.Provider, err)
+	}
+
+	// Synthetic id → a fresh handle the cache never sees; Close on return so no
+	// handle / subprocess leaks.
+	nameConvID := "namegen-" + convID
+	conv, err := prov.OpenConversation(ctx, nameConvID)
+	if err != nil {
+		return "", fmt.Errorf("open conversation: %w", err)
+	}
+	defer func() { _ = conv.Close() }()
+
+	var out strings.Builder
+	cb := func(chunk provider.StreamChunk) (*provider.ToolResult, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if chunk.Type == provider.ContentBlockTypeText {
+			out.WriteString(chunk.Content)
+		}
+		return nil, nil
+	}
+
+	// Keep macOS from App-Napping us mid-request (mirrors createLLMCaller).
+	osactivity.Begin()
+	defer osactivity.End()
+
+	_, err = conv.Submit(ctx, provider.MessageRequest{
+		SystemPrompt:   nameGenSystemPrompt,
+		Messages:       []provider.Message{{Type: "user", Content: buildNamePromptContent(prompt, response)}},
+		ConversationID: nameConvID,
+		// No tools, no extended thinking: this is a one-line summary.
+		ThinkingLevel: provider.ThinkingOff,
+	}, cb)
+	if err != nil {
+		return "", err
+	}
+
+	name := core.SanitizeName(cleanSuggestedName(out.String()))
+	if name == "" || name == "Untitled" {
+		return "", fmt.Errorf("model returned no usable title")
+	}
+	return name, nil
+}
+
+// buildNamePromptContent assembles the single user message the naming model
+// sees. Both halves are capped so a long opening exchange never bloats the
+// naming turn.
+func buildNamePromptContent(prompt, response string) string {
+	var b strings.Builder
+	b.WriteString("First user message:\n")
+	b.WriteString(clip(strings.TrimSpace(prompt), nameGenInputCap))
+	if r := strings.TrimSpace(response); r != "" {
+		b.WriteString("\n\nAssistant's first reply:\n")
+		b.WriteString(clip(r, nameGenInputCap))
+	}
+	b.WriteString("\n\nTitle:")
+	return b.String()
+}
+
+// cleanSuggestedName strips the wrapper noise a model tends to add around a
+// one-line title — surrounding quotes/backticks, a leading "Title:" label, and
+// everything after the first line — before the caller sanitizes it for the
+// filesystem.
+func cleanSuggestedName(raw string) string {
+	s := strings.TrimSpace(raw)
+	// Keep only the first non-empty line.
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			s = strings.TrimSpace(line)
+			break
+		}
+	}
+	// Drop a leading "Title:" / "Name:" label if the model added one.
+	for _, prefix := range []string{"Title:", "title:", "Name:", "name:"} {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimSpace(strings.TrimPrefix(s, prefix))
+		}
+	}
+	// Strip a single matching pair of surrounding quotes/backticks.
+	s = trimMatchingQuotes(s)
+	return strings.TrimSpace(s)
+}
+
+// trimMatchingQuotes removes one matching pair of surrounding ", ', or `.
+func trimMatchingQuotes(s string) string {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '"' || first == '\'' || first == '`') && first == last {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// clip truncates s to at most maxRunes runes on a rune boundary.
+func clip(s string, maxRunes int) string {
+	rs := []rune(s)
+	if len(rs) <= maxRunes {
+		return s
+	}
+	return string(rs[:maxRunes])
+}

--- a/cmd/juggler/server/name_gen_test.go
+++ b/cmd/juggler/server/name_gen_test.go
@@ -1,0 +1,85 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanSuggestedName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "Refactor Auth Middleware", "Refactor Auth Middleware"},
+		{"surrounding double quotes", "\"Fix Login Bug\"", "Fix Login Bug"},
+		{"surrounding single quotes", "'Fix Login Bug'", "Fix Login Bug"},
+		{"backticks", "`Add Retry Logic`", "Add Retry Logic"},
+		{"title label", "Title: Parse YAML Config", "Parse YAML Config"},
+		{"name label lowercase", "name: Parse YAML Config", "Parse YAML Config"},
+		{"leading/trailing space", "   Deploy Script   ", "Deploy Script"},
+		{"multi-line keeps first non-empty", "\n\nGraph Traversal\nBlah blah explanation", "Graph Traversal"},
+		{"label then quotes", "Title: \"Wire Up Router\"", "Wire Up Router"},
+		{"empty", "", ""},
+		{"only whitespace", "   \n  ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cleanSuggestedName(tc.in); got != tc.want {
+				t.Errorf("cleanSuggestedName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildNamePromptContent(t *testing.T) {
+	got := buildNamePromptContent("Help me fix the parser", "Sure, here is the fix")
+	if !strings.Contains(got, "First user message:") {
+		t.Errorf("missing user-message section: %q", got)
+	}
+	if !strings.Contains(got, "Help me fix the parser") {
+		t.Errorf("missing prompt text: %q", got)
+	}
+	if !strings.Contains(got, "Assistant's first reply:") {
+		t.Errorf("missing reply section: %q", got)
+	}
+	if !strings.HasSuffix(got, "Title:") {
+		t.Errorf("expected trailing 'Title:' cue, got: %q", got)
+	}
+}
+
+func TestBuildNamePromptContentEmptyResponse(t *testing.T) {
+	got := buildNamePromptContent("Just a prompt", "   ")
+	if strings.Contains(got, "Assistant's first reply:") {
+		t.Errorf("empty reply should be omitted, got: %q", got)
+	}
+	if !strings.Contains(got, "Just a prompt") {
+		t.Errorf("missing prompt text: %q", got)
+	}
+}
+
+func TestBuildNamePromptContentClipsLongInput(t *testing.T) {
+	long := strings.Repeat("x", nameGenInputCap+500)
+	got := buildNamePromptContent(long, "")
+	// The prompt half must be clipped to the cap; the wrapper text adds a
+	// bounded amount, so total x-runs cannot exceed the cap.
+	if strings.Count(got, "x") > nameGenInputCap {
+		t.Errorf("prompt not clipped: %d x's (cap %d)", strings.Count(got, "x"), nameGenInputCap)
+	}
+}
+
+func TestClipRuneBoundary(t *testing.T) {
+	// Multibyte runes must not be split mid-byte.
+	in := strings.Repeat("é", 10) // each 'é' is 2 bytes
+	got := clip(in, 4)
+	if r := []rune(got); len(r) != 4 {
+		t.Errorf("clip returned %d runes, want 4", len(r))
+	}
+	if !strings.HasPrefix(in, got) {
+		t.Errorf("clip result %q is not a prefix of input", got)
+	}
+}

--- a/cmd/juggler/server/routes.go
+++ b/cmd/juggler/server/routes.go
@@ -161,6 +161,12 @@ func (s *Server) setupSessionRoutes(sessionAPI *handlers.SessionAPI) {
 	api.HandleFunc("/session/conversations/{convId}", sessionAPI.HandleUpdateConversation).Methods("PUT")
 	api.HandleFunc("/session/conversations/{convId}", sessionAPI.HandleDeleteConversation).Methods("DELETE")
 	api.HandleFunc("/session/conversations/{convId}/name", sessionAPI.HandleRenameConversation).Methods("PATCH")
+	// AI auto-naming: turn a conversation's opening exchange into a suggested
+	// title via an isolated one-shot completion. Server-package handler: it
+	// needs provider access (credentials + InitializeProvider), which handlers
+	// must not import. Returns {name}; the frontend applies it via the rename
+	// endpoint above only if the tab is still auto-named.
+	api.HandleFunc("/session/conversations/{convId}/generate-name", s.handleGenerateConversationName).Methods("POST")
 	// Content-addressed binary assets (attached images, etc.) streamed from
 	// <convDir>/assets/<sha>.<ext>. {sha} is validated as 64-char lowercase hex.
 	api.HandleFunc("/session/conversations/{convId}/assets/{sha}", sessionAPI.HandleGetAsset).Methods("GET")

--- a/web/js-tests/unit-tests/auto-namer-test.js
+++ b/web/js-tests/unit-tests/auto-namer-test.js
@@ -1,0 +1,124 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+/**
+ * Auto-namer pure-helper tests. These pin the three decisions that gate an
+ * auto-name so the feature can never (a) overwrite a user's own tab title, (b)
+ * fire on a conversation with no opening exchange, or (c) hand the rename API a
+ * name that violates the length cap.
+ * @module unit-tests/auto-namer
+ */
+
+import { assert } from '../utilities/test-helpers.js';
+import {
+  isAutoConversationName,
+  extractFirstExchange,
+  cleanClientName
+} from '../../js/services/auto-namer.js';
+import { MAX_CONVERSATION_NAME_LENGTH } from '../../js/utils/constants.js';
+
+/**
+ * Minimal Yjs-item stand-in: a `.get(key)` map, matching what
+ * MessageThread.getMessages() yields.
+ * @param {Record<string, any>} fields
+ * @returns {{ get: (k: string) => any }} A Yjs-item stand-in with a `.get` accessor
+ */
+function item(fields) {
+  return { get: (k) => fields[k] };
+}
+
+/**
+ * @typedef {object} TestResult
+ * @property {number} passed - Count of assertions that passed.
+ * @property {number} failed - Count of assertions that failed.
+ * @property {string[]} errors - Messages from failed assertions.
+ */
+
+/**
+ * Run all auto-namer helper tests.
+ * @returns {Promise<TestResult>} Test results
+ */
+export async function runTests() {
+  let passed = 0;
+  let failed = 0;
+  const errors = [];
+  const check = (name, fn) => {
+    try {
+      fn();
+      passed++;
+    } catch (e) {
+      failed++;
+      errors.push(`${name}: ${e.message}`);
+    }
+  };
+
+  // ── isAutoConversationName ──────────────────────────────────────────────
+  check('recognises the "Task N" placeholder as auto-named', () => {
+    assert(isAutoConversationName('Task 1'), 'Task 1 should be auto');
+    assert(isAutoConversationName('Task 42'), 'Task 42 should be auto');
+    assert(isAutoConversationName('Untitled'), 'Untitled should be auto');
+  });
+
+  check('treats a user-typed title as NOT auto-named (never overwritten)', () => {
+    assert(!isAutoConversationName('Fix the parser'), 'custom title is not auto');
+    assert(!isAutoConversationName('Task'), 'bare "Task" is not the placeholder');
+    assert(!isAutoConversationName('Task 1 revisited'), 'suffixed placeholder is not auto');
+    assert(!isAutoConversationName('My Task 3'), 'prefixed placeholder is not auto');
+    assert(!isAutoConversationName(''), 'empty is not auto');
+    assert(!isAutoConversationName(/** @type {any} */ (null)), 'null is not auto');
+  });
+
+  // ── extractFirstExchange ───────────────────────────────────────────────
+  check('extracts first user prompt and first assistant reply in order', () => {
+    const thread = {
+      getMessages: () => [
+        item({ type: 'user', content: 'Help me fix the YAML parser' }),
+        item({ type: 'assistant', content: 'Sure — here is the fix.' }),
+        item({ type: 'assistant', content: 'A second reply we ignore.' })
+      ]
+    };
+    const { prompt, response } = extractFirstExchange(thread);
+    assert(prompt === 'Help me fix the YAML parser', `prompt was ${JSON.stringify(prompt)}`);
+    assert(response === 'Sure — here is the fix.', `response was ${JSON.stringify(response)}`);
+  });
+
+  check('skips non-string content and yields empty response when no assistant reply', () => {
+    const thread = {
+      getMessages: () => [
+        item({ type: 'context-item', content: { not: 'a string' } }),
+        item({ type: 'user', content: 'Just a question' })
+      ]
+    };
+    const { prompt, response } = extractFirstExchange(thread);
+    assert(prompt === 'Just a question', `prompt was ${JSON.stringify(prompt)}`);
+    assert(response === '', `response should be empty, was ${JSON.stringify(response)}`);
+  });
+
+  check('returns empty prompt for an empty / missing thread', () => {
+    assert(extractFirstExchange(null).prompt === '', 'null thread → empty prompt');
+    assert(extractFirstExchange({ getMessages: () => [] }).prompt === '', 'no messages → empty prompt');
+  });
+
+  // ── cleanClientName ────────────────────────────────────────────────────
+  check('collapses whitespace and strips surrounding quotes', () => {
+    assert(cleanClientName('  Refactor   Auth  ') === 'Refactor Auth', 'whitespace collapse');
+    assert(cleanClientName('"Fix Login Bug"') === 'Fix Login Bug', 'double quotes stripped');
+    assert(cleanClientName("'Fix Login Bug'") === 'Fix Login Bug', 'single quotes stripped');
+    assert(cleanClientName('`Add Retry`') === 'Add Retry', 'backticks stripped');
+  });
+
+  check('truncates to the shared UI length cap so the rename is never rejected', () => {
+    const long = 'x'.repeat(MAX_CONVERSATION_NAME_LENGTH + 40);
+    const out = cleanClientName(long);
+    assert(out.length === MAX_CONVERSATION_NAME_LENGTH,
+      `expected length ${MAX_CONVERSATION_NAME_LENGTH}, got ${out.length}`);
+  });
+
+  check('handles non-string / empty input safely', () => {
+    assert(cleanClientName(/** @type {any} */ (undefined)) === '', 'undefined → empty');
+    assert(cleanClientName('') === '', 'empty → empty');
+  });
+
+  return { passed, failed, errors };
+}

--- a/web/js-tests/utilities/integration-test-executor.js
+++ b/web/js-tests/utilities/integration-test-executor.js
@@ -61,6 +61,7 @@ import { runTests as runExecuteActionTests } from '../unit-tests/execute-action-
 import { runTests as runFileSystemApiTests } from '../unit-tests/filesystem-api-test.js';
 import { runTests as runGlobActionTests } from '../unit-tests/glob-action-test.js';
 import { runTests as runAskUserQuestionDetailsTests } from '../unit-tests/ask-user-question-details-test.js';
+import { runTests as runAutoNamerTests } from '../unit-tests/auto-namer-test.js';
 import { runTests as runItemAccessorTests } from '../unit-tests/item-accessor-test.js';
 import { runTests as runMessageTypeGuardTests } from '../unit-tests/message-type-guard-test.js';
 import { runTests as runModelFilterTests } from '../unit-tests/model-filter-test.js';
@@ -289,6 +290,7 @@ const UNIT_TEST_SUITES = [
   { name: 'unit:chime-recovery', run: runChimeRecoveryTests },
   { name: 'unit:context-menu', run: runContextMenuTests },
   { name: 'unit:ask-user-question-details', run: runAskUserQuestionDetailsTests },
+  { name: 'unit:auto-namer', run: runAutoNamerTests },
   { name: 'unit:extension-registry', run: runExtensionRegistryTests },
   { name: 'unit:sdk-facade-parity', run: runSdkFacadeParityTests },
   { name: 'unit:extension-collision', run: runExtensionCollisionTests },

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -22,6 +22,7 @@ import { registerConversationShortcuts } from './services/shortcut-bindings.js';
 import { markSeen } from './services/tips-manager.js';
 import { updateWindowTitle } from './utils/window-title.js';
 import { initAttention } from './utils/attention-manager.js';
+import { initAutoNamer } from './services/auto-namer.js';
 import scheduledSendService from './services/scheduled-send-service.js';
 import { initViewportFit } from './utils/viewport-fit.js';
 import { openExternalURL, externalURLFromHref } from '../sdk/lib/window-control.js';
@@ -255,6 +256,10 @@ class JugglerApp {
     // Alert (chime + tab flash + dock/tab notification) when a conversation needs
     // attention while unwatched.
     initAttention(session);
+
+    // Auto-name fresh conversations from their opening exchange (AI-generated
+    // tab titles), replacing the "Task N" placeholder once the first turn rests.
+    initAutoNamer(session);
 
     // Poll every conversation for a due scheduled send ("send after a delay")
     // and fire it — regardless of which thread is currently on screen.

--- a/web/js/services/api.js
+++ b/web/js/services/api.js
@@ -251,6 +251,24 @@ class APIService {
   }
 
   /**
+   * Ask the backend to generate a short, descriptive title for a conversation
+   * from its opening exchange. Runs an ISOLATED one-shot completion server-side
+   * (never touching the live conversation's provider session) and returns a
+   * suggested name — it does NOT rename the conversation. The caller decides
+   * whether to apply it (e.g. only while the tab is still auto-named).
+   * @param {string} conversationId
+   * @param {{ model: {provider?: string, model?: string, thinking?: string}, prompt: string, response: string }} payload
+   * @returns {Promise<{name: string}>} the suggested (server-sanitized) name
+   * @throws {Error} on 400 (bad input), 5xx (provider/credential failure)
+   */
+  async generateConversationName(conversationId, payload) {
+    return await this.request(`/session/conversations/${encodeURIComponent(conversationId)}/generate-name`, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  }
+
+  /**
    * Update a single conversation within a session
    * @param {string} conversationId
    * @param {object} conversationData - Full conversation object

--- a/web/js/services/auto-namer.js
+++ b/web/js/services/auto-namer.js
@@ -1,0 +1,200 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+/**
+ * Auto-namer — give a fresh conversation a descriptive tab title as soon as its
+ * opening exchange lands, the way t3.chat / t3code name a thread from its first
+ * message. A brand-new conversation starts as "Task N"; once its first turn
+ * comes to rest we send the opening prompt + reply to the backend, which runs a
+ * short isolated completion (see cmd/juggler/server/name_gen.go) and returns a
+ * title. We apply it through the normal rename path — but only while the tab is
+ * still auto-named, so we never clobber a title the user typed.
+ *
+ * Trigger model mirrors {@link module:utils/attention-manager}: we observe the
+ * shared LLMState status stream and act on the durable `completedTurns` edge
+ * (never the transient `status`, which sync batching can swallow). Baselines are
+ * seeded on first sight so we only name conversations whose first turn completes
+ * live this session — never a retroactive rename storm on load.
+ * @module services/auto-namer
+ */
+
+import apiService from './api.js';
+import { MAX_CONVERSATION_NAME_LENGTH } from '../utils/constants.js';
+
+/** @type {import('../model/session.js').default|null} */
+let session = null;
+
+/** Last observed completedTurns per conversation (baseline for edge detection). */
+const prevTurns = new Map();
+
+/** Conversations whose first turn we've already tried to name (permanent). */
+const attempted = new Set();
+
+/** Conversations with a naming request in flight (concurrency guard). */
+const inFlight = new Set();
+
+/**
+ * Whether `name` is an auto-generated default the auto-namer is allowed to
+ * replace. Only the names {@link Session#createConversation} assigns with no
+ * user input qualify — "Task N" and the "Untitled" fallback. Any other name
+ * (including one the user typed, or a name we already generated) is left alone.
+ * @param {string} name
+ * @returns {boolean} True if the name is an auto-generated default we may replace
+ */
+export function isAutoConversationName(name) {
+  if (typeof name !== 'string') return false;
+  const trimmed = name.trim();
+  return /^Task \d+$/.test(trimmed) || /^Untitled$/.test(trimmed);
+}
+
+/**
+ * Pull the first user message and the first assistant reply (as plain text)
+ * from a conversation's root thread — the material the title is generated from.
+ * @param {import('../model/message-thread.js').MessageThread|null|undefined} messageThread
+ * @returns {{ prompt: string, response: string }} First prompt and reply (either may be empty)
+ */
+export function extractFirstExchange(messageThread) {
+  let prompt = '';
+  let response = '';
+  const items = messageThread?.getMessages?.() || [];
+  for (const m of items) {
+    const type = m?.get?.('type');
+    const content = m?.get?.('content');
+    if (typeof content !== 'string') continue;
+    if (!prompt && type === 'user') {
+      prompt = content.trim();
+    } else if (prompt && !response && type === 'assistant') {
+      response = content.trim();
+      break;
+    }
+  }
+  return { prompt, response };
+}
+
+/**
+ * Normalise a model-suggested title for use as a tab name: collapse whitespace,
+ * strip a single pair of surrounding quotes/backticks, and truncate to the
+ * shared UI cap so the follow-up rename is never rejected for length. The server
+ * already sanitizes for the filesystem; this is the client-facing tidy-up.
+ * @param {string} raw
+ * @returns {string} A tidied, length-capped tab name (may be empty)
+ */
+export function cleanClientName(raw) {
+  if (typeof raw !== 'string') return '';
+  let s = raw.replace(/\s+/g, ' ').trim();
+  if (s.length >= 2) {
+    const first = s[0];
+    const last = s[s.length - 1];
+    if ((first === '"' || first === "'" || first === '`') && first === last) {
+      s = s.slice(1, -1).trim();
+    }
+  }
+  if (s.length > MAX_CONVERSATION_NAME_LENGTH) {
+    s = s.slice(0, MAX_CONVERSATION_NAME_LENGTH).trim();
+  }
+  return s;
+}
+
+/**
+ * Generate and (conditionally) apply a name for one conversation. Best-effort:
+ * any failure leaves the default name in place and does not throw.
+ * @param {any} conv
+ * @returns {Promise<void>}
+ * @private
+ */
+async function maybeGenerateName(conv) {
+  const id = conv?.id;
+  if (!id || attempted.has(id) || inFlight.has(id)) return;
+  if (!isAutoConversationName(conv.name)) return;
+
+  const model = conv.modelConfig;
+  if (!model || !model.provider || !model.model) return;
+
+  const { prompt, response } = extractFirstExchange(conv.rootMessageThread);
+  if (!prompt) return;
+
+  inFlight.add(id);
+  try {
+    const result = await apiService.generateConversationName(id, {
+      model: { provider: model.provider, model: model.model, thinking: model.thinking },
+      prompt,
+      response
+    });
+    // A real attempt was made — never retry, even if applying is skipped below.
+    attempted.add(id);
+
+    const finalName = cleanClientName(result?.name || '');
+    // Re-check eligibility: the user may have renamed the tab during the await.
+    if (finalName && isAutoConversationName(conv.name)) {
+      await session?.renameConversation(id, finalName);
+    }
+  } catch (err) {
+    // Best-effort. Leave `id` un-attempted so a later turn can retry; the
+    // turn-edge trigger keeps retries naturally throttled.
+    if (typeof console !== 'undefined' && console.debug) {
+      console.debug('[auto-namer] name generation failed:', err);
+    }
+  } finally {
+    inFlight.delete(id);
+  }
+}
+
+/**
+ * Handle an LLMState status change for one conversation: fire naming on the
+ * first completed turn once the conversation is idle.
+ * @param {string} convId
+ * @private
+ */
+function onStatus(convId) {
+  const conv = session?.conversations.get(convId);
+  if (!conv) return;
+
+  const llm = /** @type {any} */ (conv)._llmState;
+  const turns = conv.completedTurns;
+  const processing = !!llm && llm.isConversationProcessing(convId);
+
+  const hadTurns = prevTurns.get(convId);
+  const seeded = hadTurns !== undefined;
+  prevTurns.set(convId, turns);
+
+  // Seed the baseline on first sight without acting, so a conversation loaded
+  // from disk with turns already behind it is never retro-named.
+  if (!seeded) return;
+
+  // Act on the rising edge of completedTurns, once the turn has come to rest.
+  const turnEdge = turns > /** @type {number} */ (hadTurns) && !processing;
+  if (turnEdge && turns >= 1) {
+    void maybeGenerateName(conv);
+  }
+}
+
+/**
+ * Wire the auto-namer to a session. Idempotent per session: subscribes to the
+ * shared LLMState status stream (the one event that fires on every turn edge)
+ * and re-wires as conversations arrive.
+ * @param {import('../model/session.js').default} sess
+ * @returns {void}
+ */
+export function initAutoNamer(sess) {
+  session = sess;
+  prevTurns.clear();
+  attempted.clear();
+  inFlight.clear();
+
+  /** @type {(() => void)|null} */
+  let unsub = null;
+  const wire = () => {
+    if (unsub) return;
+    const anyConv = sess.conversations.values().next().value;
+    const llm = /** @type {any} */ (anyConv)?._llmState;
+    if (llm?.addStatusObserver) {
+      unsub = llm.addStatusObserver((/** @type {string} */ id) => onStatus(id));
+    }
+  };
+  wire();
+
+  sess.subscribe(/** @param {{type: string}} e */ (e) => {
+    if (e.type === 'conversation:created') wire();
+  });
+}

--- a/web/js/utils/constants.js
+++ b/web/js/utils/constants.js
@@ -30,11 +30,12 @@ export const YJS_SYNC_BATCH_MS = 50;
  * Maximum length (in characters) of a conversation / tab name. Enforced at
  * both the UI level (the inline-rename input's `maxlength`) and the data level
  * (`Session.renameConversation`), so it is the single source of truth for the
- * limit. Kept just under the server's filesystem-safety cap of 50 runes
+ * limit. Also the ceiling AI auto-naming truncates its suggestion to. Kept just
+ * under the server's filesystem-safety cap of 74 runes
  * (`core.SanitizedNameMaxRunes`) so a name we accept is never silently
  * truncated when the folder is written to disk.
  */
-export const MAX_CONVERSATION_NAME_LENGTH = 48;
+export const MAX_CONVERSATION_NAME_LENGTH = 72;
 
 // ===== User-facing notices =====
 


### PR DESCRIPTION
## Summary

New conversations are created as `Task 1`, `Task 2`, … — a placeholder that tells you nothing about what a tab contains. This PR names them automatically with AI, the way [t3.chat / t3code](https://github.com/pingdotgg/t3code) title a thread: from the **first user prompt + the assistant's first reply**, as soon as that opening turn comes to rest.

It also raises the conversation/tab **name length cap from 48 → 72 characters** (with a filesystem-safety byte clamp on the backend).

### How it works

**Frontend — `web/js/services/auto-namer.js`** (wired in `app.js`, next to `initAttention`)
- Observes the shared `LLMState` status stream and acts on the durable `completedTurns` rising edge — the same signal `attention-manager` uses, chosen because it survives Yjs sync batching (unlike the transient `status`).
- Only fires while the tab is **still auto-named** (`Task N` / `Untitled`), so a title you typed is never overwritten. It re-checks this after the async call too, in case you rename mid-flight.
- Baselines are **seeded on first sight**, so opening a project full of old `Task N` conversations never triggers a rename storm — only conversations whose first turn completes live get named.
- Extracts the opening exchange, asks the backend for a title, and applies it through the **existing** `renameConversation` path (folder rename + `conversations-changed` broadcast). Best-effort: any failure silently leaves the `Task N` name.

**Backend — `cmd/juggler/server/name_gen.go`**
- `POST /session/conversations/{id}/generate-name` runs **one isolated completion** with the conversation's own model/provider and returns a suggested title. It's a pure text→title endpoint; it never renames anything (the frontend owns that policy).
- Isolation is the crux: it opens its **own** short-lived provider handle under a synthetic id — entirely outside the live conversation's provider session and the server's `conversationCache` — and `Close()`s it on return. So a stateful provider (claudecode) spins a throwaway CLI for naming instead of injecting a spurious turn into your real session; a stateless provider just makes one HTTP call.

**Name-length cap**
- `MAX_CONVERSATION_NAME_LENGTH` 48 → 72 (`web/js/utils/constants.js`).
- `core.SanitizedNameMaxRunes` 50 → 74, plus a new independent `sanitizedNameMaxBytes` clamp in `SanitizeName` so an all-emoji (4-byte/rune) name still keeps the `<name>--<conv_id>` folder well under the 255-byte filename limit.

## Test plan

- [ ] `make test` passes *(CI — the desktop `app` package needs webkitgtk/CGO, unavailable in my sandbox)*
- [ ] `make lint` passes *(CI — golangci-lint not installed locally)*
- [x] `go test ./cmd/juggler/core/ ./cmd/juggler/server/` passes (new tests for the byte/rune clamp and the title-cleaning helpers)
- [x] `gofmt -l` clean, `go vet ./cmd/juggler/core ./cmd/juggler/server` clean
- [x] `eslint` and `tsc --noEmit` (lint-js / lint-types) clean on all changed JS
- [x] Node smoke test of the pure helpers (`isAutoConversationName`, `extractFirstExchange`, `cleanClientName`) — behaviour matches the new `unit:auto-namer` test

New tests:
- `cmd/juggler/core/convdir_test.go` — rune cap, multibyte byte-clamp, folder stays < 255 bytes, short names untouched.
- `cmd/juggler/server/name_gen_test.go` — `cleanSuggestedName` (quotes/labels/multiline), prompt assembly, input clipping on rune boundaries.
- `web/js-tests/unit-tests/auto-namer-test.js` (registered as `unit:auto-namer`) — auto-name eligibility, first-exchange extraction, name cleaning + length cap.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [x] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [x] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- **Cost/behaviour trade-off, chosen defaults** (happy to change): naming uses the conversation's *own* model (simplest, provider-agnostic — no new config), it's *always on* (no settings toggle, matching t3code), and it names *once* after the first exchange. Easy follow-ups if you'd prefer: a cheap fixed naming model, a settings toggle, or periodic re-naming. The isolated call means claudecode spins a short-lived CLI per new conversation — the main cost to weigh against a fixed cheap model.
- The endpoint uses real provider credentials, so in the browser test harness (no API keys) it just 500s and the frontend keeps `Task N` — existing tests that assert on tab names are unaffected.
