### PR TITLE
Render user messages as Markdown instead of plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ of changes; this project follows semantic versioning.
 
 ## [Unreleased]
 
+- Render user messages as Markdown (links, formatting, code) instead of plain text
+
 ## [0.4.2] - 2026-07-18
 
 - Added moonshot/KIMI, Copilot and llama.cpp providers, refactored and fixed other providers like ollama, codex

--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1962,7 +1962,6 @@ user-message article.user {
     font-size: 0.875rem;
     overflow-wrap: break-word;
     position: relative;
-    white-space: pre-wrap;
     margin-left: auto;
     max-width: 85%;
 }
@@ -1978,15 +1977,29 @@ user-message.conversation-item.selected article.user {
         var(--bubble-user-bg, #2d333b);
 }
 
+/* The text is rendered Markdown (see user-message.js), so line breaks and
+   paragraph spacing come from the rendered `<br>`/`<p>` elements rather than
+   preserved whitespace — no `white-space: pre-wrap` here. */
+user-message .user-message-text {
+    overflow-wrap: break-word;
+}
+
+/* Tighten the shared .markdown rhythm to fit the bubble: no top/bottom margin
+   on the first/last block so short messages don't grow the bubble beyond a
+   single-line-of-padding feel, matching the old plain-text bubble. */
+user-message .user-message-text > .markdown > :first-child {
+    margin-top: 0;
+}
+
+user-message .user-message-text > .markdown > :last-child {
+    margin-bottom: 0;
+}
+
 /* Attached images inside a user message. The text (when present) sits in its
    own block; the grid wraps a row of thumbnails below it. Each thumbnail scales
    down to a sensible max while preserving its intrinsic aspect ratio (the
    width/height attributes set on the <img>), and click-expands via the
    lightbox. */
-user-message .user-message-text {
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-}
 
 /* Collapse/expand for oversized conversation items (an extremely long user
    message, a long thread summary). Applied by utils/collapsible.js only past a

--- a/web/js/components/user-message.js
+++ b/web/js/components/user-message.js
@@ -6,11 +6,17 @@ import BaseMessage from './base-message.js';
 import apiService from '../services/api.js';
 import { openImageLightbox } from '../utils/image-lightbox.js';
 import { applyCollapsible } from '../utils/collapsible.js';
+import { renderMarkdownWrapped, decorateCodeBlocks } from '../../sdk/lib/markdown.js';
 
 /**
  * User message component - simple text bubble without icon layout. When the
  * user item carries image attachments, a thumbnail grid is rendered below the
  * text (or alone, for an image-only message).
+ *
+ * The text is rendered as Markdown (same renderer/sanitizer as assistant
+ * messages, `escapeXml: true`) so links, emphasis, lists and code the user
+ * typed or pasted render nicely instead of as raw source — while any literal
+ * `<...>` the user typed is shown as inert text rather than parsed as HTML.
  */
 class UserMessage extends BaseMessage {
   // Re-render on attachments changes too (immutable in practice, but keeps the
@@ -38,7 +44,8 @@ class UserMessage extends BaseMessage {
     if (this.content) {
       text = document.createElement('div');
       text.className = 'user-message-text';
-      text.textContent = this.content;
+      text.innerHTML = renderMarkdownWrapped(this.content, { escapeXml: true });
+      decorateCodeBlocks(text);
       article.appendChild(text);
     }
 


### PR DESCRIPTION
## Summary

User messages in the conversation UI are currently rendered as plain text (`textContent`), so any Markdown, links, or code the user typed or pasted show up as raw source instead of being formatted — similar to what [t3.chat](https://github.com/pingdotgg/t3code) already does for user turns.

This renders user messages through the same Markdown renderer/sanitizer already used for assistant messages (`renderMarkdownWrapped` from `web/sdk/lib/markdown.js`), with `escapeXml: true` (the same mode already used elsewhere for non-assistant-authored content, e.g. thread summaries in `thread-display.js`) — so:

- **Links, bold/italic, lists, code spans/blocks, tables, etc.** now render nicely in the bubble.
- Code blocks get the same copy-button treatment as assistant messages (`decorateCodeBlocks`).
- Any literal `<...>` the user typed is shown as inert escaped text rather than being interpreted as HTML/custom elements — the existing `escapeXmlTagsForMarkdown` pre-pass plus the authoritative post-parse sanitizer (`sanitizeRenderedHtml`) both still apply, so this doesn't weaken any of the existing XSS/custom-element-injection protections.

## Changes

- `web/js/components/user-message.js`: render `this.content` via `renderMarkdownWrapped(..., { escapeXml: true })` + `decorateCodeBlocks` instead of setting `textContent` directly.
- `web/css/styles.css`: drop `white-space: pre-wrap` on the user bubble (line breaks/paragraphs now come from the rendered markdown itself) and add a couple of small rules to keep the bubble's rhythm/spacing matching the previous plain-text look for short messages.
- `CHANGELOG.md`: added an entry under `[Unreleased]`.

## Testing

- `make build` (lint + Go build): passes.
- `make test-go` (Go unit tests): all green.
- `make lint-files FILES="web/js/components/user-message.js web/css/styles.css"`: passes.
- `make test` (browser/integration suite): could not be exercised in my sandbox — the WebKitGTK-driven hidden engine WebView never runs its JS test harness there (`timeout polling /api/test/names`), for reasons unrelated to this change. I confirmed this by running the exact same `make test` against an unmodified `upstream/main` checkout in the same sandbox, which fails identically. The CI workflow (`.github/workflows/ci.yml`) documents the WebKitGTK/Xvfb/sandbox environment quirks this needs even on hosted Linux runners, which my local environment doesn't fully replicate.
- Manually reasoned through the existing `web/js-tests/unit-tests/markdown-sanitizer-test.js` coverage of `renderMarkdown`, which this change now also exercises for user-authored input via the same code path already used for assistant/thread content.
