### PR TITLE
Pin spawned Claude CLI to default permission mode

### DIFF
--- a/cmd/juggler/providers/claudecode/cost_test.go
+++ b/cmd/juggler/providers/claudecode/cost_test.go
@@ -350,6 +350,24 @@ func TestCommonArgs_NoBetas(t *testing.T) {
 	}
 }
 
+// TestCommonArgs_PinsDefaultPermissionMode verifies that `--permission-mode
+// default` is always emitted — without it the CLI resolves its permission
+// mode from settings files shared with the user's interactive sessions in
+// the same folder, so a persisted plan mode would block every tool.
+func TestCommonArgs_PinsDefaultPermissionMode(t *testing.T) {
+	c := &Client{model: "sonnet"}
+	args := c.commonArgs("")
+	for i, a := range args {
+		if a == "--permission-mode" {
+			if i+1 >= len(args) || args[i+1] != "default" {
+				t.Fatalf("--permission-mode must be followed by \"default\"; got %v", args)
+			}
+			return
+		}
+	}
+	t.Fatalf("--permission-mode default must appear; got %v", args)
+}
+
 // TestListModels_OffersBaseFamilyOnly verifies that the model list is exactly
 // the base family (sonnet / opus / haiku / fable) with no `-1m` siblings.
 func TestListModels_OffersBaseFamilyOnly(t *testing.T) {

--- a/cmd/juggler/providers/claudecode/message_format.go
+++ b/cmd/juggler/providers/claudecode/message_format.go
@@ -122,6 +122,12 @@ func (c *Client) commonArgs(systemPrompt string) []string {
 		args = append(args, "--system-prompt", systemPrompt)
 	}
 	args = append(args, "--model", c.modelAlias())
+	// Without an explicit flag the CLI resolves its permission mode from
+	// settings files shared with the user's own interactive sessions in the
+	// same folder (e.g. a plan mode persisted in .claude/settings.local.json),
+	// which would strand the spawned CLI with every tool blocked. A CLI arg
+	// outranks all settings sources, so pin it to default.
+	args = append(args, "--permission-mode", "default")
 
 	if mcpConfig, err := c.buildMCPConfig(); err == nil && mcpConfig != "" {
 		args = append(args, "--mcp-config", mcpConfig)


### PR DESCRIPTION
## Summary

The spawned claude CLI inherits its permission mode from settings files it shares with the user's own interactive Claude sessions in the same folder. If one of those sessions has persisted plan mode (permissions.defaultMode: "plan" in .claude/settings.local.json), juggler's CLI starts in plan mode, every tool call fails with "Cannot call ... while in plan mode", and since ExitPlanMode is in --disallowedTools it can never get out. This pins the spawn args to --permission-mode default, which outranks all settings sources. It also matches the permissionMode: "default" juggler already writes into synthetic session entries (synthetic_resume.go).

This is the bug I reported on Discord: juggler stuck reporting plan mode even in YOLO, whenever other Claude CLI sessions were open in the same project folder.

## Test plan

- [x] `make test` passes (TestCommonArgs_NoBetas and the new TestCommonArgs_PinsDefaultPermissionMode both pass; full suite ends PASS)
- [x] `make lint` passes (via `make build`)
- [x] Manual verification on macOS: created a project folder with permissions.defaultMode set to "plan" in .claude/settings.local.json, with an interactive Claude session open in the same folder. Unpatched main reproduces the failure (every tool blocked by plan mode). With this branch, the same conversation runs tools normally through the GUI. Also confirmed at the CLI level: in the poisoned folder, the init event reports permissionMode plan without the flag and default with it.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [x] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [x] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- A constant `default` is enough. Juggler's YOLO and planning modes are juggler-side approval strategies over mcp__juggler__* tools, which --allowedTools already auto-approves in default mode, so no strategy-to-mode mapping is needed.
- This composes with the reserved set_permission_mode control message (protocol.go): the flag sets the starting mode, runtime control can still change it later if that gets wired up.
- Considered and rejected: CLAUDE_CONFIG_DIR isolation (does not help, the poisoned .claude/settings.local.json is resolved from cwd, not the config dir) and --setting-sources (skips legitimate project settings like env and hooks, and hard-errors on older CLIs).
