### PR TITLE
server: persist WebRTC identity so Direct P2P links survive restarts

### DIFF
--- a/cmd/juggler/server/connectivity.go
+++ b/cmd/juggler/server/connectivity.go
@@ -58,6 +58,10 @@ func (s *Server) handleGetConnectivity(w http.ResponseWriter, r *http.Request) {
 	// One descriptor per connected viewer (this client included). The UI excludes
 	// itself by id to show how many OTHER clients share the session.
 	clients := s.hub.viewerClients()
+	// The persistent WebRTC identity fingerprint (stable across restarts), or ""
+	// when the server is using ephemeral per-connection certificates. Exposed so
+	// the UI can show a stable device identity and a remote client can pin it.
+	peerIdentity, _ := s.PeerIdentityFingerprint()
 	handlers.WriteJSON(w, r, 0, map[string]any{
 		"lanEnabled":    s.publicMode.Load(),
 		"lanURLs":       lanURLs,
@@ -68,6 +72,7 @@ func (s *Server) handleGetConnectivity(w http.ResponseWriter, r *http.Request) {
 		"wanModes":      wanModes,
 		"clientCount":   len(clients),
 		"clients":       clients,
+		"peerIdentity":  peerIdentity,
 	})
 }
 

--- a/cmd/juggler/server/server.go
+++ b/cmd/juggler/server/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/pion/webrtc/v4"
 )
 
 // Timeout configuration for background provider/model operations.
@@ -140,6 +141,15 @@ type Server struct {
 
 	publicMode atomic.Bool                  // true = accept connections from non-localhost IPs
 	tunnel     atomic.Pointer[activeTunnel] // non-nil when a tunnel is active
+
+	// webrtcCert is this machine's persistent WebRTC identity: the DTLS
+	// certificate presented on every peer connection, loaded once at startup
+	// from the per-user config dir (see webrtc_identity.go) and reused across
+	// restarts so the peer's fingerprint — and therefore any Direct P2P link a
+	// remote client pins to it — stays stable. nil only if load/create failed,
+	// in which case pion mints an ephemeral certificate per connection (the
+	// pre-persistence behaviour).
+	webrtcCert *webrtc.Certificate
 
 	// Per-project state, swapped atomically on project change.
 	projectState atomic.Pointer[projectState]
@@ -306,6 +316,16 @@ func New(cfg Config) (*Server, error) {
 	s.switchToken <- struct{}{}
 
 	s.stats = newWSStats()
+
+	// Load (or mint on first run) the persistent WebRTC identity so peer
+	// connections present a stable DTLS fingerprint across restarts. Best-effort:
+	// on failure webrtcCert stays nil and pion falls back to a per-connection
+	// ephemeral certificate, exactly as before persistence existed.
+	if cert, err := loadOrCreateWebRTCCertificate(webRTCIdentityPath()); err != nil {
+		jlog.Info("WebRTC identity unavailable, using ephemeral certificates: %v", err)
+	} else {
+		s.webrtcCert = cert
+	}
 
 	s.seedProjectState(cfg)
 

--- a/cmd/juggler/server/tunnel_registry.go
+++ b/cmd/juggler/server/tunnel_registry.go
@@ -29,6 +29,14 @@ type TunnelHost interface {
 	// traffic to a private loopback listener serve it with this, so the LAN
 	// gate admits their traffic while the engine WS role still refuses it.
 	NewIngressHTTPServer(kind string) *http.Server
+	// PeerIdentityFingerprint returns the SHA-256 DTLS fingerprint of the
+	// server's persistent WebRTC identity, and true when one is available. It is
+	// stable across restarts (see webrtc_identity.go), so a provider that mints a
+	// shareable link — e.g. a Direct P2P rendezvous URL — can derive a stable
+	// address from it (or have the remote client pin it), keeping the same link
+	// valid after the server is stopped and started again. Returns "", false
+	// when the server is using ephemeral per-connection certificates.
+	PeerIdentityFingerprint() (string, bool)
 }
 
 // tunnelHost adapts *Server to the TunnelHost capability interface. A separate
@@ -50,6 +58,10 @@ func (h tunnelHost) NewIngressHTTPServer(kind string) *http.Server {
 		inner.ServeHTTP(w, MarkRemoteIngress(r, kind))
 	})
 	return srv
+}
+
+func (h tunnelHost) PeerIdentityFingerprint() (string, bool) {
+	return h.s.PeerIdentityFingerprint()
 }
 
 // TunnelModeSpec describes one registrable WAN tunnel mode: its identity, the

--- a/cmd/juggler/server/webrtc.go
+++ b/cmd/juggler/server/webrtc.go
@@ -125,7 +125,15 @@ func (s *Server) acceptWebRTCOffer(ctx context.Context, offer webrtc.SessionDesc
 }
 
 func (s *Server) acceptWebRTCOfferWithICEConfig(ctx context.Context, offer webrtc.SessionDescription, iceConfig webrtcICEConfig) (*webrtc.SessionDescription, error) {
-	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{ICEServers: iceConfig.Servers})
+	cfg := webrtc.Configuration{ICEServers: iceConfig.Servers}
+	// Present the persistent identity so this peer's DTLS fingerprint is stable
+	// across restarts (and across every connection within a run). When it is
+	// nil — a first run whose identity could not be persisted — pion mints an
+	// ephemeral certificate per connection, the pre-persistence behaviour.
+	if s.webrtcCert != nil {
+		cfg.Certificates = []webrtc.Certificate{*s.webrtcCert}
+	}
+	pc, err := webrtc.NewPeerConnection(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create peer connection: %w", err)
 	}

--- a/cmd/juggler/server/webrtc_identity.go
+++ b/cmd/juggler/server/webrtc_identity.go
@@ -1,0 +1,189 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package server
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"juggler/internal/atomicio"
+	"juggler/internal/jlog"
+	"juggler/internal/userpaths"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// webRTCIdentityFileName is the durable store for this machine's WebRTC peer
+// identity — the DTLS certificate (and its private key) Juggler presents on
+// every peer connection. Kept in the per-user config dir so it survives across
+// restarts, exactly like credentials.json.
+const webRTCIdentityFileName = "webrtc-identity.pem"
+
+// webRTCIdentityValidity is how long a freshly-minted identity certificate is
+// valid. WebRTC peers authenticate by the DTLS fingerprint carried in the SDP,
+// not by chain/expiry validation, so a long lifetime simply avoids ever
+// rotating (and thereby changing) a machine's stable identity in practice; the
+// file is regenerated only if it is missing, unreadable, or has lapsed.
+const webRTCIdentityValidity = 100 * 365 * 24 * time.Hour
+
+// webRTCIdentityPath returns the absolute path of the persistent WebRTC
+// identity file inside the per-user config directory.
+func webRTCIdentityPath() string {
+	return filepath.Join(userpaths.ConfigDir(), webRTCIdentityFileName)
+}
+
+// PeerIdentityFingerprint returns the SHA-256 DTLS fingerprint of this machine's
+// persistent WebRTC identity, and true when one is loaded. Because the identity
+// is reused across restarts, the fingerprint is stable — so a tunnel/rendezvous
+// provider can fold it into a shareable Direct P2P link (or a remote client can
+// pin it) and the link keeps working after Juggler is stopped and started again,
+// instead of a fresh identity invalidating it on every launch. Returns "",
+// false when no persistent identity is available (pion is minting ephemeral
+// per-connection certificates).
+func (s *Server) PeerIdentityFingerprint() (string, bool) {
+	if s.webrtcCert == nil {
+		return "", false
+	}
+	fps, err := s.webrtcCert.GetFingerprints()
+	if err != nil || len(fps) == 0 {
+		return "", false
+	}
+	return fps[0].Value, true
+}
+
+// loadOrCreateWebRTCCertificate returns the persistent WebRTC identity stored at
+// path, minting and persisting a fresh one when none is usable yet.
+//
+// Reusing one certificate across process restarts is what lets a phone keep a
+// working Direct P2P link after Juggler is stopped and started again: the peer's
+// DTLS fingerprint — the cryptographic identity a remote client (or a rendezvous
+// provider building a shareable link) can pin — stays the same instead of being
+// regenerated on every launch. The same certificate is also reused for every
+// peer connection within a single run.
+//
+// A new certificate is written atomically with owner-only permissions (it holds
+// a private key). Regeneration happens only when the file is absent, corrupt, or
+// past its NotAfter; a still-valid file is always reused verbatim so the
+// fingerprint is bit-for-bit stable.
+func loadOrCreateWebRTCCertificate(path string) (*webrtc.Certificate, error) {
+	if cert, ok := loadWebRTCCertificate(path); ok {
+		return cert, nil
+	}
+
+	cert, err := newPersistentWebRTCCertificate()
+	if err != nil {
+		return nil, err
+	}
+	if err := writeWebRTCCertificate(path, cert); err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+// loadWebRTCCertificate reads and validates a stored identity. It returns ok
+// false (rather than an error) for any recoverable condition — no file yet, an
+// unparseable file, or a lapsed certificate — so the caller mints a replacement
+// instead of failing to start.
+func loadWebRTCCertificate(path string) (*webrtc.Certificate, bool) {
+	data, err := atomicio.RobustReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			jlog.Info("WebRTC identity: cannot read %s (%v); minting a new one", path, err)
+		}
+		return nil, false
+	}
+	cert, err := webrtc.CertificateFromPEM(string(data))
+	if err != nil {
+		jlog.Info("WebRTC identity: %s is unreadable (%v); minting a new one", path, err)
+		return nil, false
+	}
+	if time.Now().After(cert.Expires()) {
+		jlog.Info("WebRTC identity: %s has expired; minting a new one", path)
+		return nil, false
+	}
+	return cert, true
+}
+
+// newPersistentWebRTCCertificate mints a long-lived self-signed certificate to
+// serve as this machine's stable WebRTC identity. It uses a far-future NotAfter
+// (unlike webrtc.GenerateCertificate, whose ~one-month lifetime would force the
+// identity to churn) so a persisted identity effectively never rotates.
+func newPersistentWebRTCCertificate() (*webrtc.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate WebRTC identity key: %w", err)
+	}
+	// A 130-bit random serial, matching webrtc.GenerateCertificate's own bound.
+	maxSerial := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(130), nil), big.NewInt(1))
+	serial, err := rand.Int(rand.Reader, maxSerial)
+	if err != nil {
+		return nil, fmt.Errorf("generate WebRTC identity serial: %w", err)
+	}
+	now := time.Now()
+	cert, err := webrtc.NewCertificate(key, x509IdentityTemplate(serial, now))
+	if err != nil {
+		return nil, fmt.Errorf("create WebRTC identity certificate: %w", err)
+	}
+	return cert, nil
+}
+
+// writeWebRTCCertificate persists cert (certificate + private key PEM blocks)
+// atomically with 0600 permissions, mirroring how credentials.json is stored:
+// a unique temp file in the same directory, then an atomic rename, so a torn or
+// world-readable file is never observable.
+func writeWebRTCCertificate(path string, cert *webrtc.Certificate) error {
+	pem, err := cert.PEM()
+	if err != nil {
+		return fmt.Errorf("encode WebRTC identity: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create WebRTC identity directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, "webrtc-identity-*.pem.tmp")
+	if err != nil {
+		return fmt.Errorf("write WebRTC identity: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write WebRTC identity: %w", err)
+	}
+	if _, err := tmp.WriteString(pem); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write WebRTC identity: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write WebRTC identity: %w", err)
+	}
+	if err := atomicio.RobustRename(tmpName, path); err != nil {
+		return fmt.Errorf("write WebRTC identity: %w", err)
+	}
+	return nil
+}
+
+// x509IdentityTemplate is the shared template for a persistent identity
+// certificate: a self-signed leaf, valid from just before now until far in the
+// future, labelled so a human inspecting the file can tell what it is.
+func x509IdentityTemplate(serial *big.Int, now time.Time) x509.Certificate {
+	name := pkix.Name{CommonName: "Juggler WebRTC identity"}
+	return x509.Certificate{
+		SerialNumber: serial,
+		Subject:      name,
+		Issuer:       name,
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(webRTCIdentityValidity),
+		Version:      2,
+	}
+}

--- a/cmd/juggler/server/webrtc_identity_test.go
+++ b/cmd/juggler/server/webrtc_identity_test.go
@@ -1,0 +1,269 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// fingerprintOf returns the SHA-256 DTLS fingerprint value of a certificate,
+// failing the test if it cannot be derived.
+func fingerprintOf(t *testing.T, cert *webrtc.Certificate) string {
+	t.Helper()
+	fps, err := cert.GetFingerprints()
+	if err != nil || len(fps) == 0 {
+		t.Fatalf("GetFingerprints: %v (n=%d)", err, len(fps))
+	}
+	return fps[0].Value
+}
+
+// TestWebRTCIdentityPersistsAndReloads is the core guarantee behind a stable
+// Direct P2P link: minting an identity, then loading it again (as a restarted
+// process would), yields the SAME fingerprint from a byte-identical file.
+func TestWebRTCIdentityPersistsAndReloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), webRTCIdentityFileName)
+
+	first, err := loadOrCreateWebRTCCertificate(path)
+	if err != nil {
+		t.Fatalf("first load-or-create: %v", err)
+	}
+	fp1 := fingerprintOf(t, first)
+
+	bytesAfterCreate, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read identity file: %v", err)
+	}
+	if len(bytesAfterCreate) == 0 {
+		t.Fatal("identity file is empty after create")
+	}
+
+	// Owner-only permissions: the file holds a private key. File modes are a
+	// POSIX concept; skip the assertion on Windows.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat identity file: %v", err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("identity file perms = %o, want 0600", perm)
+		}
+	}
+
+	second, err := loadOrCreateWebRTCCertificate(path)
+	if err != nil {
+		t.Fatalf("second load-or-create: %v", err)
+	}
+	fp2 := fingerprintOf(t, second)
+
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint changed across reload: %q -> %q", fp1, fp2)
+	}
+
+	bytesAfterReload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read identity file: %v", err)
+	}
+	if string(bytesAfterCreate) != string(bytesAfterReload) {
+		t.Fatal("identity file was rewritten on reload; must be reused verbatim")
+	}
+}
+
+// TestWebRTCIdentityRegeneratedWhenCorrupt verifies a garbage identity file is
+// replaced with a fresh, valid one rather than wedging startup.
+func TestWebRTCIdentityRegeneratedWhenCorrupt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), webRTCIdentityFileName)
+	if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	cert, err := loadOrCreateWebRTCCertificate(path)
+	if err != nil {
+		t.Fatalf("load-or-create over corrupt file: %v", err)
+	}
+	// The file is now a real identity we can reload to the same fingerprint.
+	reloaded, ok := loadWebRTCCertificate(path)
+	if !ok {
+		t.Fatal("identity file still unreadable after regeneration")
+	}
+	if got, want := fingerprintOf(t, reloaded), fingerprintOf(t, cert); got != want {
+		t.Fatalf("regenerated file fingerprint %q != returned %q", got, want)
+	}
+}
+
+// TestWebRTCIdentityRegeneratedWhenExpired verifies a lapsed identity is rotated
+// rather than reused (the rare, years-out case), producing a new fingerprint.
+func TestWebRTCIdentityRegeneratedWhenExpired(t *testing.T) {
+	path := filepath.Join(t.TempDir(), webRTCIdentityFileName)
+
+	expired := mintExpiredCertificate(t)
+	expiredFP := fingerprintOf(t, expired)
+	if err := writeWebRTCCertificate(path, expired); err != nil {
+		t.Fatalf("write expired identity: %v", err)
+	}
+	// Sanity: the loader rejects it as unusable.
+	if _, ok := loadWebRTCCertificate(path); ok {
+		t.Fatal("expired identity should not load as usable")
+	}
+
+	fresh, err := loadOrCreateWebRTCCertificate(path)
+	if err != nil {
+		t.Fatalf("load-or-create over expired file: %v", err)
+	}
+	if fingerprintOf(t, fresh) == expiredFP {
+		t.Fatal("expired identity was reused instead of rotated")
+	}
+	if time.Now().After(fresh.Expires()) {
+		t.Fatal("freshly minted identity is already expired")
+	}
+}
+
+// TestPeerIdentityFingerprint covers the accessor both ways: no identity ->
+// ("", false); a loaded identity -> its fingerprint and true.
+func TestPeerIdentityFingerprint(t *testing.T) {
+	s := &Server{}
+	if fp, ok := s.PeerIdentityFingerprint(); ok || fp != "" {
+		t.Fatalf("no identity: got (%q, %v), want (\"\", false)", fp, ok)
+	}
+
+	cert, err := loadOrCreateWebRTCCertificate(filepath.Join(t.TempDir(), webRTCIdentityFileName))
+	if err != nil {
+		t.Fatalf("load-or-create: %v", err)
+	}
+	s.webrtcCert = cert
+
+	fp, ok := s.PeerIdentityFingerprint()
+	if !ok {
+		t.Fatal("loaded identity: ok = false, want true")
+	}
+	if want := fingerprintOf(t, cert); fp != want {
+		t.Fatalf("fingerprint = %q, want %q", fp, want)
+	}
+}
+
+// TestTunnelHostExposesPeerIdentity verifies the capability handed to tunnel
+// providers reports the same stable fingerprint as the server — this is what a
+// Direct P2P provider reads to build a link that survives a restart.
+func TestTunnelHostExposesPeerIdentity(t *testing.T) {
+	cert, err := loadOrCreateWebRTCCertificate(filepath.Join(t.TempDir(), webRTCIdentityFileName))
+	if err != nil {
+		t.Fatalf("load-or-create: %v", err)
+	}
+	s := &Server{webrtcCert: cert}
+
+	hostFP, hostOK := tunnelHost{s}.PeerIdentityFingerprint()
+	srvFP, srvOK := s.PeerIdentityFingerprint()
+	if hostFP != srvFP || hostOK != srvOK {
+		t.Fatalf("tunnelHost (%q,%v) != server (%q,%v)", hostFP, hostOK, srvFP, srvOK)
+	}
+	if !hostOK {
+		t.Fatal("tunnelHost reported no identity")
+	}
+}
+
+// TestAcceptWebRTCOfferPresentsPersistentIdentityAcrossRestarts is the
+// end-to-end proof: two independent servers sharing one identity file (a
+// stop/start of the same machine) each answer a real guest offer, and both
+// answers carry the SAME persistent DTLS fingerprint. The remote peer therefore
+// sees an unchanged identity across the restart — the basis for a Direct P2P
+// link that keeps working.
+func TestAcceptWebRTCOfferPresentsPersistentIdentityAcrossRestarts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), webRTCIdentityFileName)
+
+	answerFor := func() (string, string) {
+		t.Helper()
+		cert, err := loadOrCreateWebRTCCertificate(path)
+		if err != nil {
+			t.Fatalf("load-or-create: %v", err)
+		}
+		s := &Server{webrtcCert: cert, stats: newWSStats()}
+
+		// Guest peer: empty ICE config -> host candidates only, so gathering
+		// completes promptly with no STUN/network round trip.
+		pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+		if err != nil {
+			t.Fatalf("guest NewPeerConnection: %v", err)
+		}
+		defer func() { _ = pc.Close() }()
+		if _, err := pc.CreateDataChannel("juggler", nil); err != nil {
+			t.Fatalf("guest CreateDataChannel: %v", err)
+		}
+		offer, err := pc.CreateOffer(nil)
+		if err != nil {
+			t.Fatalf("guest CreateOffer: %v", err)
+		}
+		gather := webrtc.GatheringCompletePromise(pc)
+		if err := pc.SetLocalDescription(offer); err != nil {
+			t.Fatalf("guest SetLocalDescription: %v", err)
+		}
+		select {
+		case <-gather:
+		case <-time.After(20 * time.Second):
+			t.Fatal("guest ICE gathering timed out")
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		answer, err := s.acceptWebRTCOfferWithICEConfig(ctx, *pc.LocalDescription(), webrtcICEConfig{})
+		if err != nil {
+			t.Fatalf("acceptWebRTCOffer: %v", err)
+		}
+		fp, ok := s.PeerIdentityFingerprint()
+		if !ok {
+			t.Fatal("server reported no persistent identity")
+		}
+		return answer.SDP, fp
+	}
+
+	sdp1, fp1 := answerFor() // first boot
+	sdp2, fp2 := answerFor() // after a restart
+
+	if fp1 != fp2 {
+		t.Fatalf("persistent fingerprint changed across restart: %q -> %q", fp1, fp2)
+	}
+	// The answer SDP must actually advertise the persistent fingerprint (SDP
+	// uses upper-case hex; compare case-insensitively).
+	for i, sdp := range []string{sdp1, sdp2} {
+		if !strings.Contains(strings.ToLower(sdp), strings.ToLower(fp1)) {
+			t.Fatalf("answer %d SDP does not carry the persistent fingerprint %q", i+1, fp1)
+		}
+	}
+}
+
+// mintExpiredCertificate builds a syntactically valid but already-expired
+// identity certificate for the rotation test.
+func mintExpiredCertificate(t *testing.T) *webrtc.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	name := pkix.Name{CommonName: "Juggler WebRTC identity (expired)"}
+	cert, err := webrtc.NewCertificate(key, x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      name,
+		Issuer:       name,
+		NotBefore:    time.Now().Add(-48 * time.Hour),
+		NotAfter:     time.Now().Add(-24 * time.Hour),
+		Version:      2,
+	})
+	if err != nil {
+		t.Fatalf("NewCertificate: %v", err)
+	}
+	return cert
+}


### PR DESCRIPTION
## Summary

Make the server's WebRTC peer identity **persistent across restarts** so a phone paired over **Direct P2P keeps working after Juggler is stopped and started again**, instead of every launch minting a new identity and invalidating the link.

Today `acceptWebRTCOfferWithICEConfig` creates each `PeerConnection` with a fresh pion-generated DTLS certificate, so the server's cryptographic peer identity (its DTLS fingerprint) changes on every connection — and, crucially, on every process start. Anything that pins or derives a link from that identity (a Direct P2P / rendezvous link shared to a phone) breaks on the next start.

This gives the machine a durable identity:

- **`webrtc_identity.go`** loads — or, on first run, mints and persists — a long-lived self-signed certificate under the per-user config dir (`webrtc-identity.pem`), written atomically with `0600` perms exactly like `credentials.json`. It's reused verbatim across restarts and across every peer connection within a run; it's regenerated only when the file is missing, unreadable, or expired.
- The server loads it **once at startup** and presents it on **every** peer connection. Load/create failure is **non-fatal** — it falls back to pion's per-connection ephemeral certificate, i.e. exactly the prior behaviour.
- The stable SHA-256 fingerprint is exposed to tunnel providers via the existing **`TunnelHost`** capability (`PeerIdentityFingerprint`), so a Direct P2P / rendezvous provider can derive a link that survives a restart, and it's surfaced in **`GET /api/connectivity`** (`peerIdentity`) so the UI can show a stable device identity.

No web/frontend changes required; the new `peerIdentity` field is additive.

## Test plan

New `webrtc_identity_test.go` covers:

- **Persist & reload** → byte-identical file and the same fingerprint (the restart guarantee); file is `0600`.
- **Corrupt** and **expired** identity files are rotated to a fresh valid one rather than wedging startup.
- **`PeerIdentityFingerprint`** both ways (present / absent) and via `TunnelHost`.
- **End-to-end**: two independent servers sharing one identity file (a stop/start) each answer a real pion guest offer, and both answers carry the **same** persistent fingerprint in the SDP.

- [x] `go test ./cmd/juggler/server/...` passes (incl. new tests)
- [x] `go vet ./cmd/juggler/server/` clean
- [x] `deadcode` clean (whole-program, with the Wails submodule populated)
- [ ] `make test` / `make lint` — please run in CI (local box has no Wails submodule network access for the full app build)

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [ ] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [ ] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- The certificate lifetime is deliberately long (`~100y`) because WebRTC peers authenticate by the SDP fingerprint, not chain/expiry validation; this avoids ever rotating (and thereby changing) the identity in practice. The expiry path is still handled and tested.
- Rotating the identity file (deleting `webrtc-identity.pem`) is the intended way to "reset" the machine's P2P identity.
