### PR TITLE
Fix mobile/browser project switch falsely blocked as "Already open"

### DIFF
--- a/cmd/juggler/server/handlers/project.go
+++ b/cmd/juggler/server/handlers/project.go
@@ -124,6 +124,18 @@ func (api *ProjectAPI) HandleCheckProject(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// If this path is the project *this* instance already has open, the lock is
+	// held by the very server the client is talking to — not a competing
+	// instance. Report it as the current project so the picker can act on it
+	// instead of falsely blocking with "Already open at http://…/". Without this
+	// short-circuit, browser / PWA / phone clients (which switch in place rather
+	// than spawning a new window) can never re-select their own folder, and the
+	// lock probe below would flag it as a conflict against itself.
+	if current := api.pathProvider(); current != "" && current == abs {
+		WriteJSON(w, r, 0, map[string]any{"valid": true, "path": abs, "current": true})
+		return
+	}
+
 	// Check whether another instance already has this project open.
 	if locked, existing, _ := api.checkLockedFn(abs); locked {
 		msg := "Already open in another Juggler instance"

--- a/cmd/juggler/server/handlers/project_test.go
+++ b/cmd/juggler/server/handlers/project_test.go
@@ -1,0 +1,106 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"juggler/cmd/juggler/core"
+)
+
+// decodeCheck runs HandleCheckProject for path and returns the decoded body.
+func decodeCheck(t *testing.T, api *ProjectAPI, path string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/project/check?path="+path, nil)
+	rec := httptest.NewRecorder()
+	api.HandleCheckProject(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body
+}
+
+// The project this instance already has open must never be reported as locked:
+// the lock is held by *this* server, so the picker has to be able to re-select
+// it. Regression test for the mobile/browser "Already open at http://…/" bug
+// that made switching from a phone impossible.
+func TestHandleCheckProject_CurrentProjectNotLocked(t *testing.T) {
+	dir := t.TempDir()
+
+	lockChecked := false
+	api := &ProjectAPI{
+		pathProvider: func() string { return dir },
+		checkLockedFn: func(string) (bool, *core.InstanceInfo, error) {
+			lockChecked = true
+			return true, nil, nil // would report "locked" if consulted
+		},
+	}
+
+	body := decodeCheck(t, api, dir)
+
+	if valid, _ := body["valid"].(bool); !valid {
+		t.Errorf("valid = %v, want true for the current project", body["valid"])
+	}
+	if current, _ := body["current"].(bool); !current {
+		t.Errorf("current = %v, want true for the current project", body["current"])
+	}
+	if _, hasLocked := body["locked"]; hasLocked {
+		t.Errorf("current project must not be reported as locked: %v", body)
+	}
+	if lockChecked {
+		t.Error("lock probe must be skipped for the current project")
+	}
+}
+
+// A different project genuinely held by another instance must still be flagged.
+func TestHandleCheckProject_OtherLocked(t *testing.T) {
+	current := t.TempDir()
+	other := t.TempDir()
+
+	api := &ProjectAPI{
+		pathProvider: func() string { return current },
+		checkLockedFn: func(string) (bool, *core.InstanceInfo, error) {
+			return true, nil, nil // held, no live instance info
+		},
+	}
+
+	body := decodeCheck(t, api, other)
+
+	if valid, _ := body["valid"].(bool); valid {
+		t.Errorf("valid = %v, want false for a locked project", body["valid"])
+	}
+	if locked, _ := body["locked"].(bool); !locked {
+		t.Errorf("locked = %v, want true for a locked project", body["locked"])
+	}
+}
+
+// A free directory (not current, not locked) validates normally.
+func TestHandleCheckProject_FreeDir(t *testing.T) {
+	current := t.TempDir()
+	free := t.TempDir()
+
+	api := &ProjectAPI{
+		pathProvider: func() string { return current },
+		checkLockedFn: func(string) (bool, *core.InstanceInfo, error) {
+			return false, nil, nil
+		},
+	}
+
+	body := decodeCheck(t, api, free)
+
+	if valid, _ := body["valid"].(bool); !valid {
+		t.Errorf("valid = %v, want true for a free directory", body["valid"])
+	}
+	if _, hasCurrent := body["current"]; hasCurrent {
+		t.Errorf("free directory must not be marked current: %v", body)
+	}
+}

--- a/web/js/components/project-picker.js
+++ b/web/js/components/project-picker.js
@@ -20,7 +20,7 @@ import { hasNativeHost, pickDirectory } from '../../sdk/lib/window-control.js';
 import { focusWhenShown } from '../utils/focus.js';
 
 /**
- * @typedef {(path: string) => Promise<{valid: boolean, path?: string, error?: string}>} ValidateFn
+ * @typedef {(path: string) => Promise<{valid: boolean, path?: string, error?: string, current?: boolean}>} ValidateFn
  * @typedef {{
  *   recents?: string[] | Promise<string[]>,
  *   currentPath?: string,
@@ -148,7 +148,7 @@ export function buildPickerPanel({
           const result = await validate(path);
           if (gen !== validationGen) return;
           if (result.valid) {
-            setStatus('valid', result.path || path);
+            setStatus('valid', result.current ? 'This is the current project' : (result.path || path));
             doOpen();
           } else {
             setStatus('invalid', result.error || 'Invalid path');
@@ -218,7 +218,7 @@ export function buildPickerPanel({
       const result = await validate(val);
       if (gen !== validationGen) return;
       if (result.valid) {
-        setStatus('valid', result.path || val);
+        setStatus('valid', result.current ? 'This is the current project' : (result.path || val));
       } else {
         setStatus('invalid', result.error || 'Invalid path');
       }


### PR DESCRIPTION
## Summary

Opening a different project folder from the **mobile / browser UI** was impossible: the picker always reported the currently-open project as `Already open at http://<host>:<port>/` and left the **Switch** button disabled.

The project picker validates each candidate path via `GET /api/project/check`, which probes the instance lock. That lock is held by the *very server the client is connected to*, so checking the current project reported a conflict against itself. On the desktop app a switch spawns a **new window**, so this path is rarely hit — but browser / PWA / phone clients switch **in place** and had no way around the self-inflicted "already open" error.

`HandleCheckProject` now short-circuits when the requested path is the instance's own current project: it returns `{valid: true, current: true}` and skips the lock probe entirely. The picker shows a calm *"This is the current project"* instead of the red already-open error, so the folder can be acted on. Genuine conflicts with **other** running instances are unchanged and still surface their address.

### Before / after

- **Before:** current project → `valid:false, locked:true, error:"Already open at http://localhost:3941/"` → Switch disabled.
- **After:** current project → `valid:true, current:true` → picker reads "This is the current project".
- Other-instance lock and free directories: unchanged.

## Test plan

- [x] `go test -count=1 -race ./cmd/juggler/server/handlers/` — new `project_test.go` covers current-project / other-locked / free-dir cases; `gofmt`/`go vet` clean.
- [ ] `make test` / `make lint` (full suite incl. eslint/build) — please let CI run this; eslint could not be run locally (offline, no `node_modules`). The JS change is a two-line status-string tweak and passes `node --check`.
- [x] Manual verification: from a phone connected to a running instance, open the project chip → the current folder no longer shows "Already open" and other folders switch in place.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [x] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [ ] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- Backend fix is `cmd/juggler/server/handlers/project.go` (12 lines); frontend is a cosmetic status label in `web/js/components/project-picker.js`. Switching to the current project was already a no-op server-side (`SwitchProject` returns early when `old.projectPath == newPath`), so enabling the button here is harmless.
