### PR TITLE
Fix image paste in the WebKit desktop app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ of changes; this project follows semantic versioning.
 
 ## [Unreleased]
 
+- Pasting an image now works in the WebKit desktop app: the paste handler falls back to the async Clipboard API when the paste event carries no image file synchronously
+
 ## [0.4.2] - 2026-07-18
 
 - Added moonshot/KIMI, Copilot and llama.cpp providers, refactored and fixed other providers like ollama, codex

--- a/web/js-tests/integration-tests/image-attachment-tests.js
+++ b/web/js-tests/integration-tests/image-attachment-tests.js
@@ -381,9 +381,111 @@ export const imageOnlySendTest = {
   }
 };
 
+/**
+ * @type {import('../utilities/integration-test-runner.js').IntegrationTestDefinition}
+ */
+export const pasteAsyncClipboardFallbackTest = {
+  name: 'paste-async-clipboard-fallback',
+  description: 'When the synchronous paste event carries no image file (the WebKit / Wails desktop-app case), the paste handler falls back to the async Clipboard API (navigator.clipboard.read) and routes the image blob through _handleFiles. Part A drives the fallback method directly; Part B drives it through a paste event whose synchronous data has no image.',
+  fixture: 'unit-test-fixture',
+  llmResponses: [],
+  operations: [],
+
+  async customAssertions(conversation) {
+    const tab = /** @type {any} */ (conversation.getTabElement());
+    const inputBox = tab?.getInputBox?.();
+    if (!inputBox) return; // headless — no UI to drive
+    const textarea = inputBox.querySelector('textarea');
+    if (!textarea) throw new Error('input box has no textarea');
+
+    // Stub the async Clipboard API to return exactly one PNG image. Defined as
+    // an own property on `navigator` so it shadows the prototype getter; if the
+    // environment forbids that, skip rather than fail.
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG signature
+    const fakeItem = {
+      types: ['image/png'],
+      getType: async (/** @type {string} */ t) => new Blob([pngBytes], { type: t })
+    };
+    const hadOwn = Object.prototype.hasOwnProperty.call(navigator, 'clipboard');
+    const originalDescriptor = hadOwn ? Object.getOwnPropertyDescriptor(navigator, 'clipboard') : null;
+    try {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { read: async () => [fakeItem] },
+        configurable: true
+      });
+    } catch {
+      return; // Can't stub the clipboard here — nothing to assert.
+    }
+
+    const originalHandleFiles = inputBox._handleFiles;
+    const originalFallback = inputBox._pasteImagesFromAsyncClipboard;
+    try {
+      // ── Part A: the async fallback method itself materialises the clipboard
+      //    image and routes it through _handleFiles (read → getType → File). ──
+      /** @type {any[]} */
+      const captured = [];
+      inputBox._handleFiles = (/** @type {FileList|File[]} */ files) => {
+        for (const f of Array.from(files)) captured.push(f);
+      };
+      await inputBox._pasteImagesFromAsyncClipboard();
+      if (captured.length === 0) {
+        throw new Error('async fallback did not deliver any file to _handleFiles');
+      }
+      const file = captured[0];
+      if (!file || typeof file.type !== 'string' || !file.type.startsWith('image/')) {
+        throw new Error(`async fallback delivered a non-image; got ${JSON.stringify(file)}`);
+      }
+      if (!(file.size > 0)) {
+        throw new Error(`pasted image File has no bytes; size=${file && file.size}`);
+      }
+
+      // ── Part B: a paste event that carries no synchronous image (the WebKit
+      //    case) consults the async fallback. A paste event with no
+      //    clipboardData image and no text is exactly the "no synchronous image,
+      //    no text" shape that triggers it. (A synthetic ClipboardEvent isn't
+      //    dispatched to listeners in WebKit, so a plain Event of type 'paste' —
+      //    which yields clipboardData === undefined — is used to drive the
+      //    handler's gate.) ─────────────────────────────────────────────────
+      // The input box wires its listeners in a requestAnimationFrame after
+      // render; in this headless test-pool the frame may not have run for this
+      // box yet (event-driven paths aren't exercised by the other attachment
+      // tests, which call methods directly). Ensure the paste listener is bound
+      // before driving it — this mirrors what the real app's rAF does.
+      if (!inputBox._completions) inputBox.setupListeners();
+      captured.length = 0; // reset; the real fallback (below) should refill it
+      textarea.dispatchEvent(new Event('paste', { bubbles: true, cancelable: true }));
+      try {
+        await waitFor(
+          () => captured.length > 0,
+          2000,
+          'paste event with no synchronous image consulted the async clipboard fallback'
+        );
+      } catch (err) {
+        throw new Error(
+          `${err.message} [DIAG _completions=${!!inputBox._completions} ` +
+          `sameTextarea=${textarea === inputBox.querySelector('textarea')}]`
+        );
+      }
+      if (!captured[0] || !String(captured[0].type).startsWith('image/')) {
+        throw new Error(`paste-driven fallback delivered a non-image; got ${JSON.stringify(captured[0])}`);
+      }
+    } finally {
+      inputBox._handleFiles = originalHandleFiles;
+      inputBox._pasteImagesFromAsyncClipboard = originalFallback;
+      if (originalDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', originalDescriptor);
+      } else {
+        // No own property existed before — remove ours to unshadow the getter.
+        delete (/** @type {any} */ (navigator)).clipboard;
+      }
+    }
+  }
+};
+
 export const tests = [
   compactionAttachmentStandinTest,
   rewindRestoresAttachmentsTest,
   propertiesPanelShowsAttachmentsTest,
-  imageOnlySendTest
+  imageOnlySendTest,
+  pasteAsyncClipboardFallbackTest
 ];

--- a/web/js/components/input-box.js
+++ b/web/js/components/input-box.js
@@ -417,20 +417,58 @@ class InputBox extends HTMLElement {
 
     // Paste image data (screenshot, copied image) — upload it and suppress the
     // default paste of those image items (avoids also pasting a filename).
+    //
+    // Two paths, because clipboard engines differ:
+    //   1. Synchronous — Chromium/WebView2 populate `clipboardData.items` with
+    //      the image as a `File`, readable straight off the paste event.
+    //   2. Asynchronous — WebKit (WebKitGTK on Linux, WKWebView on macOS — i.e.
+    //      the Wails desktop app) routinely exposes only text on the synchronous
+    //      paste event and hands the image out solely through the async Clipboard
+    //      API (`navigator.clipboard.read()`). Without the fallback below,
+    //      pasting a screenshot into the desktop app silently does nothing while
+    //      text paste works — exactly the drag/drop asymmetry the Wails override
+    //      above was added to fix, but for paste.
+    // The async read is gated to pastes that actually signal an image (or carry
+    // no text at all), so a plain-text paste in a browser never trips a
+    // clipboard-read permission prompt.
     textarea.addEventListener('paste', (e) => {
-      const items = e.clipboardData?.items;
-      if (!items) return;
+      const dt = e.clipboardData;
       /** @type {File[]} */
       const imageFiles = [];
-      for (const item of Array.from(items)) {
-        if (item.kind === 'file' && item.type.startsWith('image/')) {
-          const file = item.getAsFile();
-          if (file) imageFiles.push(file);
+      // Reading `items`/`getAsFile()` can throw on some engines when the event
+      // isn't a trusted user paste — never let that abort the handler before
+      // the async fallback below gets its turn.
+      try {
+        for (const item of Array.from(dt?.items || [])) {
+          if (item.kind === 'file' && item.type.startsWith('image/')) {
+            const file = item.getAsFile();
+            if (file) imageFiles.push(file);
+          }
         }
+      } catch { /* fall through to the async fallback */ }
+      if (imageFiles.length > 0) {
+        e.preventDefault();
+        this._handleFiles(imageFiles);
+        return;
       }
-      if (imageFiles.length === 0) return;
-      e.preventDefault();
-      this._handleFiles(imageFiles);
+      // Nothing usable synchronously. Only reach for the async Clipboard API
+      // when this paste plausibly carries an image: either the event advertises
+      // an image (some WebKit builds surface the type in `types`/"Files" but no
+      // File) or it carries no text at all (WebKit image-only paste, where the
+      // event exposes nothing synchronously). A plain-text paste — text present,
+      // no image signal — skips it, so browsers never see a permission prompt.
+      //
+      // Both `types` and `getData` are read defensively: WebKit restricts
+      // `getData` to trusted paste events and throws otherwise, and a throw here
+      // must not stop us from consulting the async clipboard.
+      let types = /** @type {string[]} */ ([]);
+      try { types = Array.from(dt?.types || []); } catch { /* ignore */ }
+      const hasImageSignal = types.some((t) => t.startsWith('image/')) || types.includes('Files');
+      let hasText = false;
+      try { hasText = !!(dt && dt.getData('text/plain')); } catch { /* getData may be restricted */ }
+      if (hasImageSignal || !hasText) {
+        void this._pasteImagesFromAsyncClipboard();
+      }
     });
 
     // Drag-and-drop image files anywhere onto the message box. The listeners
@@ -1240,6 +1278,47 @@ class InputBox extends HTMLElement {
       || null;
     const provider = cfg && cfg.provider ? cfg.provider : '';
     return PROVIDER_MAX_IMAGE_BYTES[provider] || MAX_ATTACHMENT_BYTES;
+  }
+
+  /**
+   * Fallback image paste for engines whose synchronous `paste` event omits the
+   * image file — notably WebKit (WebKitGTK/WKWebView), i.e. the Wails desktop
+   * app. Reads the async Clipboard API, materialises any image entries as
+   * `File`s, and routes them through the same {@link _handleFiles} path as
+   * synchronous paste / drop / picker (which validates size and uploads).
+   *
+   * Best-effort by design: a missing API, an insecure context, a denied
+   * permission, or a clipboard with no image all resolve to a silent no-op —
+   * the same outcome as before this fallback existed, so it can only ever add
+   * successful pastes, never break an existing one.
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _pasteImagesFromAsyncClipboard() {
+    const clipboard = navigator.clipboard;
+    if (!clipboard || typeof clipboard.read !== 'function') return;
+    let clipboardItems;
+    try {
+      clipboardItems = await clipboard.read();
+    } catch {
+      // No permission, insecure context, or nothing readable — nothing to do.
+      return;
+    }
+    /** @type {File[]} */
+    const files = [];
+    for (const item of clipboardItems) {
+      const type = Array.from(item.types || []).find((t) => t.startsWith('image/'));
+      if (!type) continue;
+      try {
+        const blob = await item.getType(type);
+        const ext = type.split('/')[1] || 'png';
+        // Distinct name per image so a multi-image clipboard doesn't collide.
+        files.push(new window.File([blob], `pasted-image-${Date.now()}-${files.length + 1}.${ext}`, { type }));
+      } catch {
+        // Skip an entry we can't materialise; keep any others.
+      }
+    }
+    if (files.length > 0) this._handleFiles(files);
   }
 
   /**


### PR DESCRIPTION
## Summary

Pasting an image (a screenshot or a copied image) into the conversation input did nothing in the WebKit desktop app (Wails — WebKitGTK on Linux, WKWebView on macOS), even though text paste and drag‑and‑drop worked. The paste handler read the image only from the **synchronous** `paste` event's `clipboardData.items`, which Chromium/WebView2 populate but WebKit routinely leaves empty — WebKit exposes the image solely through the **async** Clipboard API.

This adds an async `navigator.clipboard.read()` fallback: when the synchronous event carries no image file, any image entries from the async clipboard are materialised as `File`s and routed through the existing `_handleFiles` upload path (same validation/upload as drop and the file picker).

The fallback is **gated** so it only fires when a paste plausibly carries an image (the event signals an image type / `Files`, or carries no text at all). A plain‑text paste in a browser therefore never triggers a clipboard‑read permission prompt, and the synchronous path is completely unchanged for engines that already work. The synchronous extraction is additionally hardened so a `getData`/`items` access that throws on a non‑trusted event can't abort the handler before the fallback runs.

Net effect: image paste now works in the desktop app, and nothing changes for browsers where it already worked.

## Test plan

- [x] `make lint` passes
- [x] `make lint-js` / `make lint-types` pass
- [x] Browser integration tests for image attachments pass, including a new `paste-async-clipboard-fallback` test:
  - **Part A** — the async fallback method reads a stubbed clipboard image and routes it through `_handleFiles` (`read → getType → File`).
  - **Part B** — a paste event whose synchronous data carries no image consults the async fallback and delivers the image.
  - Verified in the real WebKitGTK test‑pool window: `--- PASS: TestBrowser/integration:paste-async-clipboard-fallback`, alongside the existing `compaction-attachment-standin`, `rewind-restores-attachments`, `properties-panel-shows-attachments`, and `image-only-send` tests.
- [ ] Full `make test` (whole browser + Go suite) — not run end‑to‑end in my environment; change is JS‑only (`web/js` + `web/js-tests`) and CI exercises the full suite.

## Contributor rights

- [x] Every commit has a matching `Signed-off-by:` line (`git commit -s`)
- [x] I have signed ICLA version 1.0, or will follow the CLA check's instructions
- [ ] If an employer or other entity may own this work, I have told the maintainer so CCLA coverage can be verified

## Notes for reviewers

- The gating deliberately avoids `navigator.clipboard.read()` on plain‑text pastes so browser users never see a spurious clipboard‑read permission prompt; the async path is reached only when an image is signalled or there's no text.
- `navigator.clipboard` is undefined in insecure contexts (e.g. a plain‑HTTP WAN client to a LAN IP); the fallback no‑ops gracefully there, matching prior behaviour.
- Mirrors the existing Wails‑specific hardening for drag‑and‑drop (the `installFileDropOverride` block), which fixed the same engine asymmetry for drops but not for paste.
