### PR TITLE
Enable GPU compositing for the Linux webview when a GPU is present

### DIFF
--- a/cmd/juggler-app/app_state.go
+++ b/cmd/juggler-app/app_state.go
@@ -41,15 +41,17 @@ var themeColours = map[string]application.RGBA{
 	"light": {Red: 255, Green: 255, Blue: 255, Alpha: 255},
 }
 
-// linuxWebviewGpuPolicy maps the webviewenv GPU decision to the Wails policy for
-// the *visible* viewer windows. It stays WebviewGpuPolicyNever (software
-// rendering) unless there is positive evidence a working GL stack is present
-// (see webviewenv.LinuxWebviewGpuAcceleration), in which case it returns
-// WebviewGpuPolicyAlways so WebKitGTK composites the UI's continuous animations
-// on the GPU instead of re-rasterising every frame on the main thread. The
-// engine window (off-screen, paints nothing) keeps its own hard-coded Never.
-func linuxWebviewGpuPolicy() application.WebviewGpuPolicy {
-	if accel, _ := webviewenv.LinuxWebviewGpuAcceleration(); accel {
+// linuxGpuPolicy maps the resolved webviewenv GPU decision (see
+// webviewenv.LinuxWebviewGpuAcceleration) to the Wails policy for the *visible*
+// viewer windows: WebviewGpuPolicyAlways when there is positive evidence a
+// working GL stack is present, so WebKitGTK composites the UI's continuous
+// animations on the GPU instead of re-rasterising every frame on the main
+// thread; WebviewGpuPolicyNever (software rendering) otherwise. Pure mapping —
+// the decision itself is resolved once in newAppState and stored on
+// appState.gpuPolicy. The engine window (off-screen, paints nothing) keeps its
+// own hard-coded Never.
+func linuxGpuPolicy(enabled bool) application.WebviewGpuPolicy {
+	if enabled {
 		return application.WebviewGpuPolicyAlways
 	}
 	return application.WebviewGpuPolicyNever
@@ -119,14 +121,28 @@ type appState struct {
 	ctlPort   int
 	workspace *workspaceStore
 
+	// gpuPolicy is the WebKitGTK hardware-acceleration policy applied to every
+	// visible viewer window; gpuNote is the one-line reason to log at startup.
+	// Both are resolved ONCE here in newAppState (webviewenv.LinuxWebviewGpuAcceleration
+	// reads the env override and probes /dev/dri + /proc), so every window gets
+	// the same policy and the logged reason provably matches what the windows
+	// applied — instead of each window and the startup log independently
+	// re-evaluating the decision (which also did that filesystem I/O on every
+	// window open, on macOS/Windows too).
+	gpuPolicy application.WebviewGpuPolicy
+	gpuNote   string
+
 	regOps chan func(*regState)
 	ids    chan string
 }
 
 func newAppState(devMode int) *appState {
+	gpuEnabled, gpuNote := webviewenv.LinuxWebviewGpuAcceleration()
 	a := &appState{
 		devMode:   devMode != 0,
 		workspace: newWorkspaceStore(),
+		gpuPolicy: linuxGpuPolicy(gpuEnabled),
+		gpuNote:   gpuNote,
 		regOps:    make(chan func(*regState), 32),
 		ids:       make(chan string),
 	}
@@ -613,7 +629,7 @@ func (a *appState) buildLockedProjectWindow(spec windowSpec, message, inheritedT
 		Frameless:        platformFrameless,
 		BackgroundColour: themeColours[bgTheme],
 		Mac:              application.MacWindow{TitleBar: application.MacTitleBar{AppearsTransparent: true, HideTitle: true, HideToolbarSeparator: true, FullSizeContent: true}},
-		Linux:            application.LinuxWindow{WebviewGpuPolicy: linuxWebviewGpuPolicy()},
+		Linux:            application.LinuxWindow{WebviewGpuPolicy: a.gpuPolicy},
 		Windows:          application.WindowsWindow{DisableFramelessWindowDecorations: false},
 	})
 	if win == nil {
@@ -727,17 +743,18 @@ func (a *appState) buildWindow(spec windowSpec, serverURL string, serverProc *ex
 			},
 		},
 		// WebviewGpuPolicy: hardware-accelerated compositing when a working GL
-		// stack is detected, else software (Never). Forcing acceleration on a
+		// stack is detected, else software (Never) — resolved once and stored on
+		// appState.gpuPolicy (see newAppState). Forcing acceleration on a
 		// broken/absent GL stack (VM software GL, no DRI, headless) fails during
 		// webview realisation, the native window never comes up, and the startup
-		// watchdog FATALs — so linuxWebviewGpuPolicy only returns Always on
-		// positive evidence (DRI render node + display, non-NVIDIA-proprietary),
-		// and JUGGLER_WEBVIEW_GPU overrides it. Software rendering re-rasterises
-		// the UI's continuous animations (the busy spinner) on the main thread
-		// every frame, pinning a CPU core while work is in flight; acceleration
+		// watchdog FATALs — so the decision only returns Always on positive
+		// evidence (DRI render node + display, non-NVIDIA-proprietary), and
+		// JUGGLER_WEBVIEW_GPU overrides it. Software rendering re-rasterises the
+		// UI's continuous animations (the busy spinner) on the main thread every
+		// frame, pinning a CPU core while work is in flight; acceleration
 		// composites them on the GPU and frees the main thread.
 		Linux: application.LinuxWindow{
-			WebviewGpuPolicy: linuxWebviewGpuPolicy(),
+			WebviewGpuPolicy: a.gpuPolicy,
 		},
 		Windows: application.WindowsWindow{DisableFramelessWindowDecorations: false},
 	})

--- a/cmd/juggler-app/app_state.go
+++ b/cmd/juggler-app/app_state.go
@@ -41,6 +41,20 @@ var themeColours = map[string]application.RGBA{
 	"light": {Red: 255, Green: 255, Blue: 255, Alpha: 255},
 }
 
+// linuxWebviewGpuPolicy maps the webviewenv GPU decision to the Wails policy for
+// the *visible* viewer windows. It stays WebviewGpuPolicyNever (software
+// rendering) unless there is positive evidence a working GL stack is present
+// (see webviewenv.LinuxWebviewGpuAcceleration), in which case it returns
+// WebviewGpuPolicyAlways so WebKitGTK composites the UI's continuous animations
+// on the GPU instead of re-rasterising every frame on the main thread. The
+// engine window (off-screen, paints nothing) keeps its own hard-coded Never.
+func linuxWebviewGpuPolicy() application.WebviewGpuPolicy {
+	if accel, _ := webviewenv.LinuxWebviewGpuAcceleration(); accel {
+		return application.WebviewGpuPolicyAlways
+	}
+	return application.WebviewGpuPolicyNever
+}
+
 // winEntry tracks one open window and the server URL it views. Geometry is NOT
 // stored here — it lives server-side in the session (see window_state_client.go);
 // this only carries the window's workspace identity (spec) and the live frame
@@ -599,7 +613,7 @@ func (a *appState) buildLockedProjectWindow(spec windowSpec, message, inheritedT
 		Frameless:        platformFrameless,
 		BackgroundColour: themeColours[bgTheme],
 		Mac:              application.MacWindow{TitleBar: application.MacTitleBar{AppearsTransparent: true, HideTitle: true, HideToolbarSeparator: true, FullSizeContent: true}},
-		Linux:            application.LinuxWindow{WebviewGpuPolicy: application.WebviewGpuPolicyNever},
+		Linux:            application.LinuxWindow{WebviewGpuPolicy: linuxWebviewGpuPolicy()},
 		Windows:          application.WindowsWindow{DisableFramelessWindowDecorations: false},
 	})
 	if win == nil {
@@ -712,15 +726,18 @@ func (a *appState) buildWindow(spec windowSpec, serverURL string, serverProc *ex
 				FullSizeContent:      true,
 			},
 		},
-		// WebviewGpuPolicy defaults to the zero value WebviewGpuPolicyAlways, which
-		// forces WebKitGTK's hardware-accelerated compositing path. On a broken or
-		// absent GL stack (VM software GL, no DRI, headless) that path fails during
-		// webview realisation, the native window widget never comes up, and the
-		// window never becomes visible (the startup watchdog then FATALs). Never
-		// maps to webkit_settings_set_hardware_acceleration_policy(NEVER) — software
-		// compositing, which this text UI doesn't miss — so the window always paints.
+		// WebviewGpuPolicy: hardware-accelerated compositing when a working GL
+		// stack is detected, else software (Never). Forcing acceleration on a
+		// broken/absent GL stack (VM software GL, no DRI, headless) fails during
+		// webview realisation, the native window never comes up, and the startup
+		// watchdog FATALs — so linuxWebviewGpuPolicy only returns Always on
+		// positive evidence (DRI render node + display, non-NVIDIA-proprietary),
+		// and JUGGLER_WEBVIEW_GPU overrides it. Software rendering re-rasterises
+		// the UI's continuous animations (the busy spinner) on the main thread
+		// every frame, pinning a CPU core while work is in flight; acceleration
+		// composites them on the GPU and frees the main thread.
 		Linux: application.LinuxWindow{
-			WebviewGpuPolicy: application.WebviewGpuPolicyNever,
+			WebviewGpuPolicy: linuxWebviewGpuPolicy(),
 		},
 		Windows: application.WindowsWindow{DisableFramelessWindowDecorations: false},
 	})

--- a/cmd/juggler-app/app_state.go
+++ b/cmd/juggler-app/app_state.go
@@ -748,7 +748,8 @@ func (a *appState) buildWindow(spec windowSpec, serverURL string, serverProc *ex
 		// broken/absent GL stack (VM software GL, no DRI, headless) fails during
 		// webview realisation, the native window never comes up, and the startup
 		// watchdog FATALs — so the decision only returns Always on positive
-		// evidence (DRI render node + display, non-NVIDIA-proprietary), and
+		// evidence (a usable DRI render node + display; only a machine whose sole
+		// render node is the NVIDIA proprietary driver stays software), and
 		// JUGGLER_WEBVIEW_GPU overrides it. Software rendering re-rasterises the
 		// UI's continuous animations (the busy spinner) on the main thread every
 		// frame, pinning a CPU core while work is in flight; acceleration

--- a/cmd/juggler-app/main.go
+++ b/cmd/juggler-app/main.go
@@ -53,6 +53,12 @@ func main() {
 	if note := webviewenv.PrepareLinuxWebKit(); note != "" {
 		logf("%s", note)
 	}
+	// Resolve the visible-window GPU policy once at startup and log the decision
+	// (and why). The per-window sites call linuxWebviewGpuPolicy() → the same
+	// webviewenv decision; logging it here keeps the reasoning in one place.
+	if _, note := webviewenv.LinuxWebviewGpuAcceleration(); note != "" {
+		logf("%s", note)
+	}
 	app := newAppState(devMode)
 
 	// Build the application — and acquire the single-instance lock — BEFORE

--- a/cmd/juggler-app/main.go
+++ b/cmd/juggler-app/main.go
@@ -53,13 +53,14 @@ func main() {
 	if note := webviewenv.PrepareLinuxWebKit(); note != "" {
 		logf("%s", note)
 	}
-	// Resolve the visible-window GPU policy once at startup and log the decision
-	// (and why). The per-window sites call linuxWebviewGpuPolicy() → the same
-	// webviewenv decision; logging it here keeps the reasoning in one place.
-	if _, note := webviewenv.LinuxWebviewGpuAcceleration(); note != "" {
-		logf("%s", note)
-	}
 	app := newAppState(devMode)
+	// The visible-window GPU policy is resolved exactly once, in newAppState, and
+	// stored on appState. Log that same resolved reason here so the startup line
+	// provably matches the policy every window actually applied (no independent
+	// re-evaluation that could drift from it).
+	if app.gpuNote != "" {
+		logf("%s", app.gpuNote)
+	}
 
 	// Build the application — and acquire the single-instance lock — BEFORE
 	// resolving any server. If another juggler-app is already running, this call

--- a/internal/webviewenv/webviewenv.go
+++ b/internal/webviewenv/webviewenv.go
@@ -19,6 +19,7 @@ package webviewenv
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -133,6 +134,116 @@ func sandboxRestrictedFrom(read func(string) (string, bool)) bool {
 		}
 	}
 	return false
+}
+
+// gpuOverrideEnv lets the user force the Linux WebKitGTK webview's hardware
+// acceleration policy, bypassing autodetection. Case-insensitive values:
+// "always"/"on"/"1"/"true"/"yes" force acceleration; "never"/"off"/"0"/"false"/
+// "no" force software rendering; "auto"/"" (or any unrecognised value)
+// autodetect.
+const gpuOverrideEnv = "JUGGLER_WEBVIEW_GPU"
+
+// gpuOverrideMode is the parsed intent of gpuOverrideEnv.
+type gpuOverrideMode int
+
+const (
+	gpuAuto gpuOverrideMode = iota
+	gpuForceOn
+	gpuForceOff
+)
+
+// gpuOverride parses the JUGGLER_WEBVIEW_GPU value into an intent.
+func gpuOverride(v string) gpuOverrideMode {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "always", "on", "1", "true", "yes":
+		return gpuForceOn
+	case "never", "off", "0", "false", "no":
+		return gpuForceOff
+	default:
+		return gpuAuto
+	}
+}
+
+// LinuxWebviewGpuAcceleration decides whether the *visible* Linux WebKitGTK
+// viewer window should use hardware-accelerated compositing (which the caller
+// maps to application.WebviewGpuPolicyAlways) rather than software rendering
+// (WebviewGpuPolicyNever). It returns the decision and a one-line note for the
+// caller to log — the same idiom as PrepareLinuxWebKit.
+//
+// Why this is decided rather than a constant: forcing acceleration on a broken
+// or absent GL stack (VM software GL, no DRI render node, headless) makes
+// WebKitGTK's webview realisation fail and the window never appears — which is
+// why the safe historical default was software. But software compositing
+// re-rasterises every animated frame on the CPU, and Juggler's UI animates
+// continuously while a conversation runs (the busy spinner), so on a machine
+// that genuinely has a working GPU that pins a CPU core near saturation for the
+// whole time work is in flight and stalls the UI. This enables acceleration
+// only when there is positive evidence the GL stack can support it — a DRI
+// render node exists, a display is present, and it is not the crash-prone
+// NVIDIA-proprietary case — and never in the headless/CI case, so the
+// crash-safety that motivated the software default is preserved. The
+// JUGGLER_WEBVIEW_GPU env var overrides the decision either way.
+//
+// Off Linux the return is (false, ""): the LinuxWindow policy field is ignored
+// on other platforms, and the engine window (off-screen, paints nothing) keeps
+// its own hard-coded Never regardless.
+func LinuxWebviewGpuAcceleration() (enabled bool, note string) {
+	return linuxWebviewGpuAcceleration(
+		runtime.GOOS,
+		os.Getenv(gpuOverrideEnv),
+		os.Getenv("DISPLAY"),
+		os.Getenv("WAYLAND_DISPLAY"),
+		hasDRIRenderNode,
+		nvidiaProprietaryPresent,
+	)
+}
+
+// linuxWebviewGpuAcceleration is the testable core of LinuxWebviewGpuAcceleration:
+// the OS, the override value, the two display env vars, and the two host probes
+// are all injected so every branch is reachable from any host.
+func linuxWebviewGpuAcceleration(goos, override, display, wayland string, hasRenderNode, nvidiaProprietary func() bool) (bool, string) {
+	if goos != "linux" {
+		return false, ""
+	}
+	switch gpuOverride(override) {
+	case gpuForceOn:
+		return true, "webview GPU acceleration forced ON via " + gpuOverrideEnv
+	case gpuForceOff:
+		return false, "webview GPU acceleration forced OFF via " + gpuOverrideEnv + " — using software rendering"
+	}
+	// Autodetect. Every negative branch is also the crash-safe branch, so
+	// software rendering is chosen whenever acceleration might fail to come up.
+	if display == "" && wayland == "" {
+		// Headless: Preflight already reports the missing display, so stay
+		// software without an extra (redundant) log line.
+		return false, ""
+	}
+	if !hasRenderNode() {
+		return false, "no DRI render node (/dev/dri/renderD*) detected — using software rendering for the webview"
+	}
+	if nvidiaProprietary() {
+		return false, "NVIDIA proprietary driver detected — using software rendering for the webview (set " + gpuOverrideEnv + "=always to override)"
+	}
+	return true, "GPU acceleration enabled for the webview (DRI render node present)"
+}
+
+// hasDRIRenderNode reports whether the kernel exposes at least one DRM render
+// node (/dev/dri/renderD*), the interface WebKitGTK's accelerated compositor
+// draws through. Absent on headless CI runners and pure-software-GL setups,
+// which is exactly where forcing acceleration would fail to realise a window.
+func hasDRIRenderNode() bool {
+	m, _ := filepath.Glob("/dev/dri/renderD*")
+	return len(m) > 0
+}
+
+// nvidiaProprietaryPresent reports whether the NVIDIA proprietary driver is
+// loaded — the open `nouveau` driver does not create this file. The proprietary
+// driver is the well-known crash/instability case for WebKitGTK's DMABUF and
+// accelerated-compositing path, so autodetection keeps it on software rendering
+// unless the user forces acceleration via JUGGLER_WEBVIEW_GPU=always.
+func nvidiaProprietaryPresent() bool {
+	_, err := os.Stat("/proc/driver/nvidia/version")
+	return err == nil
 }
 
 // linuxHost carries the host facts that tailor the Linux remediation message:

--- a/internal/webviewenv/webviewenv.go
+++ b/internal/webviewenv/webviewenv.go
@@ -157,11 +157,13 @@ const gpuOverrideEnv = "JUGGLER_WEBVIEW_GPU"
 // continuously while a conversation runs (the busy spinner), so on a machine
 // that genuinely has a working GPU that pins a CPU core near saturation for the
 // whole time work is in flight and stalls the UI. This enables acceleration
-// only when there is positive evidence the GL stack can support it — a DRI
-// render node exists, a display is present, and it is not the crash-prone
-// NVIDIA-proprietary case — and never in the headless/CI case, so the
-// crash-safety that motivated the software default is preserved. The
-// JUGGLER_WEBVIEW_GPU env var overrides the decision either way.
+// whenever a usable DRI render node and a display are present. The single
+// exception is a machine whose *only* render node is the crash-prone NVIDIA
+// proprietary driver: there WebKitGTK's DMABUF path is unstable and nothing
+// else can composite, so it stays on software. A machine that also has a
+// non-NVIDIA render node (an Optimus/PRIME laptop, or a multi-GPU desktop with
+// an Intel/AMD iGPU) composites fine through that node and is left accelerated.
+// The JUGGLER_WEBVIEW_GPU env var overrides the decision either way.
 //
 // Off Linux the return is (false, ""): the LinuxWindow policy field is ignored
 // on other platforms, and the engine window (off-screen, paints nothing) keeps
@@ -172,15 +174,16 @@ func LinuxWebviewGpuAcceleration() (enabled bool, note string) {
 		os.Getenv(gpuOverrideEnv),
 		os.Getenv("DISPLAY"),
 		os.Getenv("WAYLAND_DISPLAY"),
-		hasDRIRenderNode,
-		nvidiaProprietaryPresent,
+		renderNodeDrivers,
 	)
 }
 
 // linuxWebviewGpuAcceleration is the testable core of LinuxWebviewGpuAcceleration:
-// the OS, the override value, the two display env vars, and the two host probes
-// are all injected so every branch is reachable from any host.
-func linuxWebviewGpuAcceleration(goos, override, display, wayland string, hasRenderNode, nvidiaProprietary func() bool) (bool, string) {
+// the OS, the override value, the two display env vars, and the render-node probe
+// are all injected so every branch is reachable from any host. renderNodeDrivers
+// returns the DRM driver name behind each /dev/dri/renderD* node ("" when a
+// node's driver can't be identified).
+func linuxWebviewGpuAcceleration(goos, override, display, wayland string, renderNodeDrivers func() []string) (bool, string) {
 	if goos != "linux" {
 		return false, ""
 	}
@@ -200,32 +203,52 @@ func linuxWebviewGpuAcceleration(goos, override, display, wayland string, hasRen
 		// software without an extra (redundant) log line.
 		return false, ""
 	}
-	if !hasRenderNode() {
+	drivers := renderNodeDrivers()
+	if len(drivers) == 0 {
 		return false, "no DRI render node (/dev/dri/renderD*) detected — using software rendering for the webview"
 	}
-	if nvidiaProprietary() {
-		return false, "NVIDIA proprietary driver detected — using software rendering for the webview (set " + gpuOverrideEnv + "=always to override)"
+	// Enable as long as at least one render node is NOT the crash-prone NVIDIA
+	// proprietary driver: WebKitGTK can composite through that node (the iGPU on
+	// an Optimus/PRIME laptop, or an Intel/AMD GPU on a multi-GPU desktop). The
+	// mere presence of the NVIDIA proprietary module says nothing about which GPU
+	// drives the webview, so only the *sole-NVIDIA* case falls back to software.
+	for _, d := range drivers {
+		if !isNVIDIAProprietaryDriver(d) {
+			return true, "GPU acceleration enabled for the webview (usable DRI render node present)"
+		}
 	}
-	return true, "GPU acceleration enabled for the webview (DRI render node present)"
+	return false, "the only DRI render node is the NVIDIA proprietary driver — using software rendering for the webview (set " + gpuOverrideEnv + "=always to override)"
 }
 
-// hasDRIRenderNode reports whether the kernel exposes at least one DRM render
-// node (/dev/dri/renderD*), the interface WebKitGTK's accelerated compositor
-// draws through. Absent on headless CI runners and pure-software-GL setups,
-// which is exactly where forcing acceleration would fail to realise a window.
-func hasDRIRenderNode() bool {
-	m, _ := filepath.Glob("/dev/dri/renderD*")
-	return len(m) > 0
+// renderNodeDrivers returns the DRM kernel driver bound to each /dev/dri/renderD*
+// node — the render nodes WebKitGTK's accelerated compositor draws through. The
+// driver name is read from sysfs (/sys/class/drm/<node>/device/driver, a symlink
+// into the bus driver dir), e.g. "i915"/"xe" (Intel), "amdgpu"/"radeon" (AMD),
+// "nvidia" (NVIDIA proprietary), "nouveau" (open NVIDIA). An entry is "" when the
+// node exists but its driver can't be resolved (treated downstream as usable, not
+// NVIDIA-proprietary). An empty slice means there is no render node at all
+// (headless CI runners, pure-software-GL setups) — where forcing acceleration
+// would fail to realise a window.
+func renderNodeDrivers() []string {
+	nodes, _ := filepath.Glob("/dev/dri/renderD*")
+	drivers := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		link, err := os.Readlink("/sys/class/drm/" + filepath.Base(n) + "/device/driver")
+		if err != nil {
+			drivers = append(drivers, "")
+			continue
+		}
+		drivers = append(drivers, filepath.Base(link))
+	}
+	return drivers
 }
 
-// nvidiaProprietaryPresent reports whether the NVIDIA proprietary driver is
-// loaded — the open `nouveau` driver does not create this file. The proprietary
-// driver is the well-known crash/instability case for WebKitGTK's DMABUF and
-// accelerated-compositing path, so autodetection keeps it on software rendering
-// unless the user forces acceleration via JUGGLER_WEBVIEW_GPU=always.
-func nvidiaProprietaryPresent() bool {
-	_, err := os.Stat("/proc/driver/nvidia/version")
-	return err == nil
+// isNVIDIAProprietaryDriver reports whether a DRM driver name is the proprietary
+// NVIDIA driver ("nvidia") — the well-known crash/instability case for
+// WebKitGTK's DMABUF and accelerated-compositing path. The open "nouveau" driver
+// is NOT this case and composites fine, so it is deliberately excluded.
+func isNVIDIAProprietaryDriver(driver string) bool {
+	return driver == "nvidia"
 }
 
 // linuxHost carries the host facts that tailor the Linux remediation message:

--- a/internal/webviewenv/webviewenv.go
+++ b/internal/webviewenv/webviewenv.go
@@ -136,33 +136,12 @@ func sandboxRestrictedFrom(read func(string) (string, bool)) bool {
 	return false
 }
 
-// gpuOverrideEnv lets the user force the Linux WebKitGTK webview's hardware
-// acceleration policy, bypassing autodetection. Case-insensitive values:
-// "always"/"on"/"1"/"true"/"yes" force acceleration; "never"/"off"/"0"/"false"/
-// "no" force software rendering; "auto"/"" (or any unrecognised value)
-// autodetect.
+// gpuOverrideEnv lets the user override the Linux WebKitGTK webview's hardware
+// acceleration autodetection. Recognised values (case-insensitive, surrounding
+// whitespace ignored): "always" forces acceleration, "never" forces software
+// rendering, and "auto" — the default when unset — autodetects. Any other value
+// is treated as "auto".
 const gpuOverrideEnv = "JUGGLER_WEBVIEW_GPU"
-
-// gpuOverrideMode is the parsed intent of gpuOverrideEnv.
-type gpuOverrideMode int
-
-const (
-	gpuAuto gpuOverrideMode = iota
-	gpuForceOn
-	gpuForceOff
-)
-
-// gpuOverride parses the JUGGLER_WEBVIEW_GPU value into an intent.
-func gpuOverride(v string) gpuOverrideMode {
-	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "always", "on", "1", "true", "yes":
-		return gpuForceOn
-	case "never", "off", "0", "false", "no":
-		return gpuForceOff
-	default:
-		return gpuAuto
-	}
-}
 
 // LinuxWebviewGpuAcceleration decides whether the *visible* Linux WebKitGTK
 // viewer window should use hardware-accelerated compositing (which the caller
@@ -205,10 +184,13 @@ func linuxWebviewGpuAcceleration(goos, override, display, wayland string, hasRen
 	if goos != "linux" {
 		return false, ""
 	}
-	switch gpuOverride(override) {
-	case gpuForceOn:
+	// JUGGLER_WEBVIEW_GPU overrides autodetection. Only the two documented
+	// forcing values are recognised; "auto" (the third documented value), unset,
+	// or anything else falls through to autodetection below.
+	switch strings.ToLower(strings.TrimSpace(override)) {
+	case "always":
 		return true, "webview GPU acceleration forced ON via " + gpuOverrideEnv
-	case gpuForceOff:
+	case "never":
 		return false, "webview GPU acceleration forced OFF via " + gpuOverrideEnv + " — using software rendering"
 	}
 	// Autodetect. Every negative branch is also the crash-safe branch, so

--- a/internal/webviewenv/webviewenv_test.go
+++ b/internal/webviewenv/webviewenv_test.go
@@ -183,32 +183,6 @@ func TestDetectLinuxHost(t *testing.T) {
 	}
 }
 
-func TestGpuOverride(t *testing.T) {
-	cases := []struct {
-		in   string
-		want gpuOverrideMode
-	}{
-		{"always", gpuForceOn},
-		{"ON", gpuForceOn},
-		{"1", gpuForceOn},
-		{"true", gpuForceOn},
-		{" Yes ", gpuForceOn},
-		{"never", gpuForceOff},
-		{"off", gpuForceOff},
-		{"0", gpuForceOff},
-		{"false", gpuForceOff},
-		{"no", gpuForceOff},
-		{"auto", gpuAuto},
-		{"", gpuAuto},
-		{"garbage", gpuAuto},
-	}
-	for _, tc := range cases {
-		if got := gpuOverride(tc.in); got != tc.want {
-			t.Errorf("gpuOverride(%q) = %v, want %v", tc.in, got, tc.want)
-		}
-	}
-}
-
 func TestLinuxWebviewGpuAcceleration(t *testing.T) {
 	yes := func() bool { return true }
 	no := func() bool { return false }
@@ -232,6 +206,12 @@ func TestLinuxWebviewGpuAcceleration(t *testing.T) {
 		// Override wins over autodetection, in both directions.
 		{"force on overrides headless", "linux", "always", "", "", no, yes, true, true},
 		{"force off overrides a good GPU", "linux", "never", ":0", "", yes, no, false, true},
+		// "always"/"never" are case-insensitive and whitespace-tolerant.
+		{"force on is case/space-insensitive", "linux", " Always ", "", "", no, yes, true, true},
+		// The other documented value ("auto") and any unrecognised value fall
+		// through to autodetection rather than forcing anything.
+		{"auto autodetects (good GPU → on)", "linux", "auto", ":0", "", yes, no, true, true},
+		{"unknown value autodetects (headless → software, silent)", "linux", "garbage", "", "", yes, no, false, false},
 		// Off Linux: never accelerated, never a note (field is ignored there).
 		{"darwin is (false, \"\")", "darwin", "always", ":0", "", yes, no, false, false},
 		{"windows is (false, \"\")", "windows", "always", ":0", "", yes, no, false, false},

--- a/internal/webviewenv/webviewenv_test.go
+++ b/internal/webviewenv/webviewenv_test.go
@@ -182,3 +182,69 @@ func TestDetectLinuxHost(t *testing.T) {
 		})
 	}
 }
+
+func TestGpuOverride(t *testing.T) {
+	cases := []struct {
+		in   string
+		want gpuOverrideMode
+	}{
+		{"always", gpuForceOn},
+		{"ON", gpuForceOn},
+		{"1", gpuForceOn},
+		{"true", gpuForceOn},
+		{" Yes ", gpuForceOn},
+		{"never", gpuForceOff},
+		{"off", gpuForceOff},
+		{"0", gpuForceOff},
+		{"false", gpuForceOff},
+		{"no", gpuForceOff},
+		{"auto", gpuAuto},
+		{"", gpuAuto},
+		{"garbage", gpuAuto},
+	}
+	for _, tc := range cases {
+		if got := gpuOverride(tc.in); got != tc.want {
+			t.Errorf("gpuOverride(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLinuxWebviewGpuAcceleration(t *testing.T) {
+	yes := func() bool { return true }
+	no := func() bool { return false }
+	cases := []struct {
+		name             string
+		goos             string
+		override         string
+		display, wayland string
+		renderNode       func() bool
+		nvidia           func() bool
+		wantEnabled      bool
+		wantNote         bool // whether a (non-empty) note is expected
+	}{
+		// Autodetect: a normal desktop GPU (render node, display, non-NVIDIA).
+		{"linux desktop GPU auto-enables", "linux", "", ":0", "", yes, no, true, true},
+		{"linux wayland desktop GPU auto-enables", "linux", "", "", "wayland-0", yes, no, true, true},
+		// Autodetect negatives — all must stay software (crash-safe).
+		{"linux headless stays software silently", "linux", "", "", "", yes, no, false, false},
+		{"linux no render node stays software", "linux", "", ":0", "", no, no, false, true},
+		{"linux nvidia proprietary stays software", "linux", "", ":0", "", yes, yes, false, true},
+		// Override wins over autodetection, in both directions.
+		{"force on overrides headless", "linux", "always", "", "", no, yes, true, true},
+		{"force off overrides a good GPU", "linux", "never", ":0", "", yes, no, false, true},
+		// Off Linux: never accelerated, never a note (field is ignored there).
+		{"darwin is (false, \"\")", "darwin", "always", ":0", "", yes, no, false, false},
+		{"windows is (false, \"\")", "windows", "always", ":0", "", yes, no, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enabled, note := linuxWebviewGpuAcceleration(tc.goos, tc.override, tc.display, tc.wayland, tc.renderNode, tc.nvidia)
+			if enabled != tc.wantEnabled {
+				t.Errorf("enabled = %v, want %v", enabled, tc.wantEnabled)
+			}
+			if (note != "") != tc.wantNote {
+				t.Errorf("note = %q, want non-empty=%v", note, tc.wantNote)
+			}
+		})
+	}
+}

--- a/internal/webviewenv/webviewenv_test.go
+++ b/internal/webviewenv/webviewenv_test.go
@@ -184,41 +184,55 @@ func TestDetectLinuxHost(t *testing.T) {
 }
 
 func TestLinuxWebviewGpuAcceleration(t *testing.T) {
-	yes := func() bool { return true }
-	no := func() bool { return false }
+	// Render-node fixtures: the DRM driver behind each /dev/dri/renderD* node.
+	none := func() []string { return nil }
+	intel := func() []string { return []string{"i915"} }        // ordinary iGPU
+	amd := func() []string { return []string{"amdgpu"} }        // ordinary dGPU
+	nvidiaOnly := func() []string { return []string{"nvidia"} } // sole NVIDIA proprietary
+	nouveauOnly := func() []string { return []string{"nouveau"} }
+	optimus := func() []string { return []string{"i915", "nvidia"} } // iGPU + NVIDIA dGPU
+	unknown := func() []string { return []string{""} }               // node present, driver unresolved
 	cases := []struct {
 		name             string
 		goos             string
 		override         string
 		display, wayland string
-		renderNode       func() bool
-		nvidia           func() bool
+		renderNodes      func() []string
 		wantEnabled      bool
 		wantNote         bool // whether a (non-empty) note is expected
 	}{
 		// Autodetect: a normal desktop GPU (render node, display, non-NVIDIA).
-		{"linux desktop GPU auto-enables", "linux", "", ":0", "", yes, no, true, true},
-		{"linux wayland desktop GPU auto-enables", "linux", "", "", "wayland-0", yes, no, true, true},
+		{"linux intel GPU auto-enables", "linux", "", ":0", "", intel, true, true},
+		{"linux amd GPU auto-enables", "linux", "", ":0", "", amd, true, true},
+		{"linux wayland desktop GPU auto-enables", "linux", "", "", "wayland-0", intel, true, true},
+		// The Optimus/PRIME + multi-GPU case the NVIDIA-presence probe got wrong:
+		// a non-NVIDIA render node also exists, so acceleration stays ON.
+		{"linux optimus (iGPU + NVIDIA) auto-enables", "linux", "", ":0", "", optimus, true, true},
+		// Open nouveau composites fine — not the proprietary crash case.
+		{"linux nouveau-only auto-enables", "linux", "", ":0", "", nouveauOnly, true, true},
+		// A render node with an unidentifiable driver is treated as usable.
+		{"linux unknown-driver render node auto-enables", "linux", "", ":0", "", unknown, true, true},
 		// Autodetect negatives — all must stay software (crash-safe).
-		{"linux headless stays software silently", "linux", "", "", "", yes, no, false, false},
-		{"linux no render node stays software", "linux", "", ":0", "", no, no, false, true},
-		{"linux nvidia proprietary stays software", "linux", "", ":0", "", yes, yes, false, true},
+		{"linux headless stays software silently", "linux", "", "", "", intel, false, false},
+		{"linux no render node stays software", "linux", "", ":0", "", none, false, true},
+		{"linux sole-NVIDIA-proprietary stays software", "linux", "", ":0", "", nvidiaOnly, false, true},
 		// Override wins over autodetection, in both directions.
-		{"force on overrides headless", "linux", "always", "", "", no, yes, true, true},
-		{"force off overrides a good GPU", "linux", "never", ":0", "", yes, no, false, true},
+		{"force on overrides headless", "linux", "always", "", "", none, true, true},
+		{"force off overrides a good GPU", "linux", "never", ":0", "", intel, false, true},
+		{"force on overrides sole-NVIDIA", "linux", "always", ":0", "", nvidiaOnly, true, true},
 		// "always"/"never" are case-insensitive and whitespace-tolerant.
-		{"force on is case/space-insensitive", "linux", " Always ", "", "", no, yes, true, true},
+		{"force on is case/space-insensitive", "linux", " Always ", "", "", none, true, true},
 		// The other documented value ("auto") and any unrecognised value fall
 		// through to autodetection rather than forcing anything.
-		{"auto autodetects (good GPU → on)", "linux", "auto", ":0", "", yes, no, true, true},
-		{"unknown value autodetects (headless → software, silent)", "linux", "garbage", "", "", yes, no, false, false},
+		{"auto autodetects (good GPU → on)", "linux", "auto", ":0", "", intel, true, true},
+		{"unknown value autodetects (headless → software, silent)", "linux", "garbage", "", "", intel, false, false},
 		// Off Linux: never accelerated, never a note (field is ignored there).
-		{"darwin is (false, \"\")", "darwin", "always", ":0", "", yes, no, false, false},
-		{"windows is (false, \"\")", "windows", "always", ":0", "", yes, no, false, false},
+		{"darwin is (false, \"\")", "darwin", "always", ":0", "", intel, false, false},
+		{"windows is (false, \"\")", "windows", "always", ":0", "", intel, false, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			enabled, note := linuxWebviewGpuAcceleration(tc.goos, tc.override, tc.display, tc.wayland, tc.renderNode, tc.nvidia)
+			enabled, note := linuxWebviewGpuAcceleration(tc.goos, tc.override, tc.display, tc.wayland, tc.renderNodes)
 			if enabled != tc.wantEnabled {
 				t.Errorf("enabled = %v, want %v", enabled, tc.wantEnabled)
 			}
@@ -226,5 +240,20 @@ func TestLinuxWebviewGpuAcceleration(t *testing.T) {
 				t.Errorf("note = %q, want non-empty=%v", note, tc.wantNote)
 			}
 		})
+	}
+}
+
+func TestIsNVIDIAProprietaryDriver(t *testing.T) {
+	proprietary := []string{"nvidia"}
+	notProprietary := []string{"nouveau", "i915", "xe", "amdgpu", "radeon", "", "NVIDIA"}
+	for _, d := range proprietary {
+		if !isNVIDIAProprietaryDriver(d) {
+			t.Errorf("isNVIDIAProprietaryDriver(%q) = false, want true", d)
+		}
+	}
+	for _, d := range notProprietary {
+		if isNVIDIAProprietaryDriver(d) {
+			t.Errorf("isNVIDIAProprietaryDriver(%q) = true, want false", d)
+		}
 	}
 }


### PR DESCRIPTION
## Problem

The Juggler desktop UI intermittently freezes at ~100% CPU on Linux, then recovers. Profiling the running app pinned it to **one WebKit `WebProcess` main thread stuck at a steady ~90%**, dragging the shared `juggler-app` GTK shell to ~50% (so *all* windows stutter). It is not the backend — the server is idle when this happens.

Sampling the pegged main thread (via `gdb`) caught it red-handed in the rendering pipeline:

```
WTF::RunLoop::run()
  -> g_main_context_dispatch                  (WebKit rendering-update timer)
    -> libwebkitgtk … recursive render-tree walk   (layout/paint)
      -> __roundf                              (rounding coords to device pixels)
```

This is a **full layout+paint pass firing every refresh tick**. The cause: the visible viewer windows hard-code `WebviewGpuPolicyNever` (software compositing), so there is no GPU process and every animated frame is re-rasterised on the CPU. The UI animates continuously while a conversation runs (the `juggler-spinner`, tab/icon pulses), so a core stays pinned the whole time work is in flight, and recovers only when the spinner is removed.

## Why it was `Never` (and why we can't just flip it)

`Never` was deliberate: forcing acceleration (`Always`) on a broken or absent GL stack (VM software GL, no DRI render node, headless/CI) makes WebKitGTK's webview realisation fail — the window never appears and the startup watchdog FATALs. WebKitGTK 6.0 also removed `ON_DEMAND`, so the only choices are `Always` or `Never`.

## Fix

Enable acceleration when there is evidence a working GL stack is present, defaulting to software otherwise:

- a DRI render node (`/dev/dri/renderD*`) exists, **and**
- a display is present (`DISPLAY` or `WAYLAND_DISPLAY`), **and**
- that render node is not the *sole* NVIDIA-proprietary node.

That last point is deliberately narrow. The presence of the NVIDIA proprietary module says nothing about which GPU drives the webview, so we only fall back to software when the NVIDIA proprietary driver is the **only** render node. A machine that also exposes a non-NVIDIA render node — an Optimus/PRIME laptop, or a multi-GPU desktop with an Intel/AMD iGPU — composites fine through that node and stays accelerated. The DMABUF-instability worry that motivates the sole-NVIDIA fallback also has the documented `WEBKIT_DISABLE_DMABUF_RENDERER` / `WEBKIT_DISABLE_COMPOSITING_MODE` knobs (see `remediation()`) as a finer lever.

Every negative branch stays on software rendering, so **headless/CI (no render node, xvfb) is unchanged** and the crash-safety that motivated the software default is preserved. On a machine with a usable (non-sole-NVIDIA) render node — the common case — acceleration turns on, which is what takes the continuous layout/paint off the CPU. This is an autodetection heuristic, not a guarantee: on the one machine class it can't serve (sole NVIDIA proprietary) it stays software, and `JUGGLER_WEBVIEW_GPU=always` forces it on there if the user knows their stack is fine.

`JUGGLER_WEBVIEW_GPU=always|never|auto` overrides the decision either way (escape hatch for exotic stacks); unset/unrecognised means `auto`.

**Scope:** only the two *visible* viewer windows change. The engine window is off-screen and paints nothing, so it keeps its own hard-coded `Never` (its existing comment already anticipated the viewer being accelerated).

## Implementation

- `internal/webviewenv`: new `LinuxWebviewGpuAcceleration()` (returns the decision + a one-line note to log, matching the existing `PrepareLinuxWebKit` idiom) with a fully injected, testable core. The render-node probe reads the DRM driver behind each `/dev/dri/renderD*` from sysfs so the sole-NVIDIA gate is per-node, not "is the module loaded anywhere".
- `cmd/juggler-app/app_state.go`: the decision is resolved **once** in `newAppState` and the resolved `application.WebviewGpuPolicy` + note stored on `appState`; both viewer windows read `appState.gpuPolicy`.
- `cmd/juggler-app/main.go`: logs `appState.gpuNote` — the same resolved value the windows applied, so the startup line can't drift from reality (and the probe runs once, not per window / per OS).

## Testing

- `make lint` — clean (Go + types + JS + CSS).
- `make test-go` — all `./cmd/...` tests pass under `-race`.
- Table tests in `webviewenv_test.go` cover every branch of the decision core — including the Optimus/multi-GPU case (iGPU + NVIDIA → still enabled), sole-NVIDIA and nouveau-only, the three documented override values, and the per-OS early return.

## How to verify the fix

On a GPU machine, launch and confirm the startup log shows *"GPU acceleration enabled for the webview (usable DRI render node present)"*, then run a conversation and watch the `WebProcess` CPU stay low (a WebKit GPU process should now appear). Set `JUGGLER_WEBVIEW_GPU=never` to reproduce the old software-render behaviour.
