### PR TITLE
Cut the software-render CPU cost of always-running UI animations

### DIFF
--- a/web/css/components.css
+++ b/web/css/components.css
@@ -2780,6 +2780,15 @@ juggler-spinner .js-pivot {
     top: 50%;
     width: 0;
     height: 0;
+
+    /* Promote each animated node to its own compositing layer so the per-frame
+       transform is a cheap layer transform, not a repaint of the surrounding
+       UI. This matters most under software compositing (WebviewGpuPolicyNever,
+       and any host without a usable GPU), where an un-layered transform forces
+       WebKit to re-rasterise the region every frame on the main thread — the
+       spinner is the dominant always-running animation, so confining its
+       repaint to a few tiny layers is the biggest win available there. */
+    will-change: transform;
     animation: juggler-spinner-orbit var(--duration) linear infinite;
 }
 
@@ -2792,6 +2801,9 @@ juggler-spinner .js-club {
     height: var(--js-club-h);
     left: calc(var(--js-club-w) / -2);
     top: calc((var(--js-radius) + var(--js-club-h) / 2) * -1);
+
+    /* Own compositing layer — see the note on .js-pivot above. */
+    will-change: transform;
     animation: juggler-spinner-spin var(--duration) linear infinite;
 }
 
@@ -2841,6 +2853,22 @@ juggler-spinner .js-club svg {
    wanted here, override the --duration *variable* (not animation-duration) so
    the calc()'d per-club phase delays scale with it and the clubs stay 120°
    apart — overriding animation-duration alone bunches them. */
+
+/* Pause ALL CSS animations while the document is hidden — minimised, fully
+   occluded, or on another virtual desktop. A hidden window paints nothing a
+   user can see, yet its continuously-running indicators (the busy spinner, the
+   tab/icon pulses) keep the WebProcess re-rasterising frames every refresh tick
+   — pure waste, and expensive under software compositing where each frame is a
+   CPU repaint. `data-doc-hidden` is toggled on <html> by the Page Visibility
+   hook in app.js; animations resume instantly on the next paint when the window
+   becomes visible again. Scoped high enough (attribute selector) to override
+   the per-element animation shorthands, and !important guards against any
+   equally-specific rule. */
+:root[data-doc-hidden] *,
+:root[data-doc-hidden] *::before,
+:root[data-doc-hidden] *::after {
+    animation-play-state: paused !important;
+}
 
 /* Model Selector - Hint when no providers configured */
 .menu-item-hint {

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -75,6 +75,26 @@ class JugglerApp {
     });
   }
 
+  /**
+   * Pause CSS animations while the document is hidden (window minimised, fully
+   * occluded, or on another virtual desktop). Reflects `document.hidden` onto a
+   * `data-doc-hidden` attribute on <html>, which the stylesheet keys off to set
+   * `animation-play-state: paused` everywhere. A hidden window paints nothing a
+   * user can see, yet its continuously-running indicators (the busy spinner, the
+   * tab/icon pulses) would otherwise keep the WebProcess re-rasterising unseen
+   * frames every refresh tick — wasteful in general, and a whole CPU core under
+   * software compositing. Animations resume on the next paint when the window
+   * becomes visible again.
+   * @private
+   */
+  _initDocumentVisibilityPause() {
+    const sync = () => {
+      document.documentElement.toggleAttribute('data-doc-hidden', document.hidden);
+    };
+    document.addEventListener('visibilitychange', sync);
+    sync(); // reflect the initial state immediately
+  }
+
   /** @private */
   async setup() {
     // Get component references. contextPanel, conversationArea, and
@@ -114,6 +134,10 @@ class JugglerApp {
     // on-screen keyboard opens by fitting <app-container> to the visual viewport
     // instead of letting the browser scroll the whole page up.
     initViewportFit();
+
+    // Pause CSS animations when this window is hidden, so its always-running
+    // indicators don't burn CPU re-rasterising frames nobody can see.
+    this._initDocumentVisibilityPause();
 
     // External-link safety net. Markdown-rendered content (LLM and message
     // output) emits bare <a href> anchors at many render sites; a plain


### PR DESCRIPTION
## Problem

Juggler's UI animates **continuously while a conversation is working** — the `juggler-spinner` (six `transform`-animated SVG nodes) in the footer and each running tab, plus the tab/icon pulses. When the webview composites in **software** (`WebviewGpuPolicyNever`, or any host without a usable GPU), an un-layered animated `transform` forces WebKit to re-rasterise the region on the `WebProcess` main thread **every refresh tick**, pinning a CPU core the whole time work is in flight (confirmed by stack-sampling the pegged main thread — it's in the rendering-update timer's layout/paint walk).

This is the mitigation for the case where GPU compositing stays off (CI, VMs, or an explicit `JUGGLER_WEBVIEW_GPU=never`). It stacks with — and is independent of — enabling acceleration.

## Changes

Two small, independent reductions, both no-ops when the GPU path is available:

1. **Layer-isolate the spinner** — `will-change: transform` on `.js-pivot` and `.js-club`. Each animated node gets its own compositing layer, so the per-frame transform is a cheap layer transform instead of a repaint of the surrounding UI. The spinner is the dominant always-running animation, so confining its repaint is the biggest win under software compositing.

2. **Pause animations when the document is hidden** — a Page Visibility hook in `app.js` reflects `document.hidden` onto a `data-doc-hidden` attribute on `<html>`; the stylesheet pauses *all* animations while it's set. A hidden window (minimised, fully occluded, another virtual desktop) paints nothing visible, so keeping its spinner/pulses running is pure waste. Animations resume on the next paint when the window is visible again.

## Notes

- **No visible change while a window is on screen.** Pausing is keyed strictly on `document.hidden`, not focus — a visible but unfocused window that's working keeps animating.
- The pause rule is scoped via an attribute selector with `!important` so it reliably overrides the per-element `animation` shorthands (`!important` is already used elsewhere in the stylesheet and permitted by the stylelint config).

## Testing

`make lint-css` / `make lint-js` / `make lint-types` all clean. The visibility hook is a pure attribute reflection with no effect on existing behaviour while visible.
