### PR TITLE
Add Mistral AI provider

### DIFF
--- a/cmd/juggler/app/run.go
+++ b/cmd/juggler/app/run.go
@@ -31,11 +31,9 @@ import (
 	"juggler/cmd/juggler/providers/deepseek"
 	"juggler/cmd/juggler/providers/gemini"
 	"juggler/cmd/juggler/providers/llamacpp"
+	"juggler/cmd/juggler/providers/mistral"
 	"juggler/cmd/juggler/providers/moonshot"
 	"juggler/cmd/juggler/providers/ollama"
-	"juggler/cmd/juggler/providers/openai"
-	"juggler/cmd/juggler/providers/openaicodex"
-	"juggler/cmd/juggler/providers/openaicompat"
 	"juggler/cmd/juggler/providers/openrouter"
 	"juggler/cmd/juggler/providers/streamidle"
 	"juggler/cmd/juggler/providers/zai"
@@ -152,6 +150,7 @@ func registerProviders() {
 	deepseek.Register()
 	gemini.Register()
 	llamacpp.Register()
+	mistral.Register()
 	moonshot.Register()
 	ollama.Register()
 	openai.Register()

--- a/cmd/juggler/providers/mistral/client.go
+++ b/cmd/juggler/providers/mistral/client.go
@@ -1,0 +1,43 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package mistral
+
+import (
+	"juggler/cmd/juggler/providers/openaibase"
+)
+
+// Register adds the Mistral AI provider to the global registry. Called
+// explicitly from main; no init()-time side effects.
+//
+// Mistral speaks the OpenAI Chat-Completions protocol, so it rides the shared
+// openaibase machinery. Its API key is independent of the generic
+// OpenAI-compatible provider, so a user can configure both side by side.
+func Register() {
+	openaibase.Register(openaibase.Descriptor{
+		Name:              "mistral",
+		DisplayName:       "Mistral AI",
+		Description:       "Mistral AI models via the official OpenAI-compatible API.",
+		ConfigKeyName:     "mistral_api_key",
+		EnvVarName:        "MISTRAL_API_KEY",
+		APIKeyURL:         "https://console.mistral.ai/settings/keys",
+		DisplayProvider:   "Mistral AI",
+		ContextWindowCaps: contextWindowCaps,
+		MaxOutputCaps:     maxOutputCaps,
+		InputModalitiesFn: inputModalities,
+		ThinkingSpecFn:    thinkingSpec,
+		BaseURL:           "https://api.mistral.ai/v1",
+	})
+}
+
+// inputModalities returns the input modalities a Mistral model accepts.
+// Vision-capable models accept images; others are text-only.
+func inputModalities(modelID string) []string {
+	switch modelID {
+	case "codestral-latest", "devstral-medium-latest", "mistral-tiny-latest":
+		return nil
+	default:
+		return []string{"image"}
+	}
+}

--- a/cmd/juggler/providers/mistral/models.go
+++ b/cmd/juggler/providers/mistral/models.go
@@ -1,0 +1,56 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package mistral
+
+import (
+	"strings"
+
+	"juggler/cmd/juggler/providers/openaibase"
+	provider "juggler/cmd/juggler/providers/registry"
+	"juggler/cmd/juggler/providers/utils"
+)
+
+// ModelContextWindows maps Mistral model names to context window sizes (tokens).
+// Source: https://mistral.ai/models and the /v1/models API endpoint.
+var ModelContextWindows = map[string]int{
+	"codestral-latest":        256000,
+	"devstral-medium-latest":  262144,
+	"magistral-medium-latest": 131072,
+	"magistral-small-latest":  262144,
+	"ministral-3b-latest":     131072,
+	"ministral-8b-latest":     262144,
+	"ministral-14b-latest":    262144,
+	"mistral-large-latest":    262144,
+	"mistral-medium-latest":   131072,
+	"mistral-small-latest":    262144,
+	"mistral-tiny-latest":     131072,
+}
+
+const DefaultContextWindow = 131072
+
+const DefaultMaxOutputTokens = 16384
+
+var (
+	contextWindowCaps = utils.ModelCaps{Default: DefaultContextWindow, Overrides: ModelContextWindows}
+	maxOutputCaps     = utils.ModelCaps{Default: DefaultMaxOutputTokens}
+)
+
+// thinkingSpec classifies a Mistral model's reasoning-effort support. Only
+// Magistral models expose reasoning through the OpenAI-shaped reasoning_effort
+// field, with low/medium/high levels.
+func thinkingSpec(modelID string) openaibase.ThinkingSpec {
+	if strings.HasPrefix(strings.ToLower(modelID), "magistral") {
+		return openaibase.ThinkingSpec{
+			Levels:  []string{provider.ThinkingLow, provider.ThinkingMedium, provider.ThinkingHigh},
+			Default: provider.ThinkingMedium,
+			Effort: map[string]string{
+				provider.ThinkingLow:    "low",
+				provider.ThinkingMedium: "medium",
+				provider.ThinkingHigh:   "high",
+			},
+		}
+	}
+	return openaibase.ThinkingSpec{}
+}


### PR DESCRIPTION
Registers Mistral AI as an OpenAI-compatible provider with:
- Base URL `https://api.mistral.ai/v1`
- Config key `mistral_api_key` / env `MISTRAL_API_KEY`
- Vision modalities per model
- Thinking spec for Magistral models (low/medium/high)
