### PR TITLE
Add 1M context windows for DeepSeek v4 API models

### DIFF
--- a/cmd/juggler/providers/deepseek/models.go
+++ b/cmd/juggler/providers/deepseek/models.go
@@ -7,10 +7,13 @@ package deepseek
 import "juggler/cmd/juggler/providers/utils"
 
 // ModelContextWindows maps DeepSeek model names to context window sizes (tokens).
+// The v4 API models carry a 1M-token window (DeepSeek API docs, Models & Pricing).
 var ModelContextWindows = map[string]int{
-	"deepseek-chat":     128000,
-	"deepseek-reasoner": 128000,
-	"deepseek-coder":    128000,
+	"deepseek-chat":       128000,
+	"deepseek-reasoner":   128000,
+	"deepseek-coder":      128000,
+	"deepseek-v4-flash":   1000000,
+	"deepseek-v4-pro":     1000000,
 }
 
 // DefaultContextWindow is used for unknown DeepSeek models.

--- a/cmd/juggler/providers/deepseek/models_test.go
+++ b/cmd/juggler/providers/deepseek/models_test.go
@@ -34,6 +34,14 @@ func TestDeepSeekContextWindow(t *testing.T) {
 	if got := contextWindowCaps.Lookup("deepseek-reasoner"); got != 128000 {
 		t.Errorf("context window(deepseek-reasoner) = %d, want 128000", got)
 	}
+	// The v4 API models advertise a 1M-token window (DeepSeek API docs,
+	// Models & Pricing) — without these entries they'd fall to the 128k
+	// default and conversations would be compacted ~8x too early.
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		if got := contextWindowCaps.Lookup(model); got != 1000000 {
+			t.Errorf("context window(%s) = %d, want 1000000", model, got)
+		}
+	}
 	if got := contextWindowCaps.Lookup("deepseek-vNext"); got != DefaultContextWindow {
 		t.Errorf("context window(unknown) = %d, want default %d", got, DefaultContextWindow)
 	}


### PR DESCRIPTION
## Context

Base: `develop` (ca9aac5). Motivation: the DeepSeek API serves `deepseek-v4-flash` and `deepseek-v4-pro` with a 1M-token context window and 384K max output ([DeepSeek API docs, Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing)). Both ids were missing from `ModelContextWindows`, so `DefaultContextWindow` (128000) applied: the model selector showed "128k" and conversations hit the compaction budget ~8x earlier than the model allows. The mismatch was confirmed live against v0.5.2.

## Changes

- `7c3b192` — add `deepseek-v4-flash` and `deepseek-v4-pro` to `ModelContextWindows` at 1000000, and pin both in `TestDeepSeekContextWindow`. Unknown-model fallback (`deepseek-vNext` case) is untouched.

## Verification

- `go test ./cmd/juggler/providers/deepseek/` — ok (0.004s).
- `go build ./cmd/juggler/providers/...` — ok.
- Full code path to the UI traced and unit-verified: `ModelContextWindows` → `contextWindowCaps` → `ContextWindowCaps` descriptor → synthesized `ContextWindowFn` → `ListModelsWithInfo` → `providers-update` → `applyProvidersContextWindow` → `formatTokens(1000000)` = "1M".
- Not verified: the actual pixel in the model selector. A rebuilt binary is required, and the public repo cannot build one — `go.mod` replaces `github.com/wailsapp/wails/v3` with `./3rdparty/wails/v3`, which is not in the public tree (build fails: "replacement directory ./3rdparty/wails/v3 does not exist"). Left to maintainer CI.

## Deferred

- Max-output caps for the v4 models: the API documents 384K, but `DefaultMaxOutputTokens` (32768) still applies to them. Intentionally out of scope for this PR.
- The DeepSeek thinking-mode `reasoning_content` echo fails after delegated subthread turns (400 on continuation); being reported separately with logs.
