### PR TITLE
Echo reasoning_content on every split assistant tool_use message

### DIFF
--- a/cmd/juggler/providers/openaibase/client.go
+++ b/cmd/juggler/providers/openaibase/client.go
@@ -968,7 +968,12 @@ func transformMessages(messages []provider.Message, useDeveloperRole, echoReason
 
 	// Track assistant message accumulation (text + tool calls grouped together).
 	// pendingReasoning holds the turn's chain-of-thought, replayed back to the
-	// API when echoReasoning is set (see Quirks.EchoReasoningContent).
+	// API when echoReasoning is set (see Quirks.EchoReasoningContent). It is
+	// reset at turn boundaries only (a user/context message, or a new thinking
+	// block): a turn that produces several assistant messages on the wire (e.g.
+	// delegated tool calls emitted as thread items, each a use/result pair)
+	// must carry the turn's reasoning on EVERY assistant tool_use message —
+	// DeepSeek rejects a tool-call assistant message without it.
 	var pendingAssistantText strings.Builder
 	var pendingReasoning strings.Builder
 	var pendingToolCalls []openai.ChatCompletionMessageToolCallUnionParam
@@ -996,8 +1001,10 @@ func transformMessages(messages []provider.Message, useDeveloperRole, echoReason
 			})
 		}
 		pendingAssistantText.Reset()
-		pendingReasoning.Reset()
 		pendingToolCalls = nil
+		// Note: pendingReasoning deliberately survives the flush — see the
+		// reasoning comment above. It is cleared by the user/context branch
+		// and replaced by the next thinking block.
 	}
 
 	for _, msg := range messages {
@@ -1010,6 +1017,9 @@ func transformMessages(messages []provider.Message, useDeveloperRole, echoReason
 		case "user", "context-item", "context-item-updated", "guidance", "system-reminder":
 			// Flush any pending assistant content first
 			flushAssistant()
+			// Turn boundary: the reasoning was already replayed on the turn's
+			// assistant message(s); do not leak it into the next turn.
+			pendingReasoning.Reset()
 			// Skip empty user messages with no images - some APIs (e.g., Z.AI)
 			// reject empty content.
 			if userMsg, ok := buildChatUserMessage(msg); ok {
@@ -1025,6 +1035,9 @@ func transformMessages(messages []provider.Message, useDeveloperRole, echoReason
 			// thinking mode requires the reasoning be replayed on the next
 			// request, so accumulate it when echoReasoning is set.
 			if echoReasoning {
+				// A new block starts a new turn's chain-of-thought; replace
+				// any reasoning left over from the previous turn.
+				pendingReasoning.Reset()
 				pendingReasoning.WriteString(msg.Content)
 			}
 

--- a/cmd/juggler/providers/openaibase/reasoning_echo_test.go
+++ b/cmd/juggler/providers/openaibase/reasoning_echo_test.go
@@ -78,3 +78,51 @@ func TestEchoReasoningContentDisabledDropsThinking(t *testing.T) {
 		t.Fatalf("assistant content missing; got %s", got)
 	}
 }
+
+// splitAssistantJSONs returns every assistant message in the transformed set,
+// in wire order. reasoning_echo_test's single-message helper cannot express
+// multi-assistant wire shapes.
+func splitAssistantJSONs(t *testing.T, msgs []openai.ChatCompletionMessageParamUnion) []string {
+	t.Helper()
+	var out []string
+	for _, m := range msgs {
+		if m.OfAssistant != nil {
+			data, err := json.Marshal(m)
+			if err != nil {
+				t.Fatalf("marshal assistant message: %v", err)
+			}
+			out = append(out, string(data))
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no assistant message found in transformed set")
+	}
+	return out
+}
+
+// TestEchoReasoningContentCoversSplitAssistantTurns pins the delegated-subthread
+// case: a turn whose tool calls arrive as several use/result pairs (thread items
+// emit one pair each) flushes one assistant message per pair. DeepSeek requires
+// reasoning_content on EVERY assistant message carrying tool_calls — the second
+// split message without it 400s with "The `reasoning_content` in the thinking
+// mode must be passed back to the API."
+func TestEchoReasoningContentCoversSplitAssistantTurns(t *testing.T) {
+	msgs := transformMessages([]provider.Message{
+		{Type: "user", Content: "Summarize these pages."},
+		{Type: "thinking", Content: "I need both pages; delegate each fetch."},
+		{Type: "tool-use", ToolUseID: "call_1", ToolName: "WebFetch", ToolInput: map[string]any{"url": "a"}},
+		{Type: "tool-result", ToolUseID: "call_1", Content: "page a"},
+		{Type: "tool-use", ToolUseID: "call_2", ToolName: "WebFetch", ToolInput: map[string]any{"url": "b"}},
+		{Type: "tool-result", ToolUseID: "call_2", Content: "page b"},
+	}, false, true, "")
+
+	got := splitAssistantJSONs(t, msgs)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 assistant messages (one per use/result pair), got %d: %v", len(got), got)
+	}
+	for i, m := range got {
+		if !strings.Contains(m, `"reasoning_content":"I need both pages; delegate each fetch."`) {
+			t.Fatalf("assistant message %d missing reasoning_content (DeepSeek 400s without it); got %s", i, m)
+		}
+	}
+}


### PR DESCRIPTION
## Context

Base: `develop` (ca9aac5). DeepSeek thinking mode requires `reasoning_content` on **every** assistant message that carries `tool_calls` (verified against the live API: the shape with a second tool-call assistant message lacking reasoning 400s with "The `reasoning_content` in the thinking mode must be passed back to the API."; the same shape with the reasoning echoed returns 200). Follow-up to the closed #1, which fixed the parallel tool-action batching case.

The gap: a turn whose tool calls arrive as several use/result pairs flushes one assistant message per pair. Delegated tools (WebFetch etc.) become **thread items**; each thread item emits its own tool_use/tool_result pair (`appendThreadMessages`), so a single delegating turn produces two assistant messages while the worker stores one `thinking` item per turn. `transformMessages` attached the reasoning only to the first flushed message — the second went out bare and DeepSeek 400'd. Confirmed from a live conversation document: items `[thinking, thread(WebFetch call_00), thread(WebFetch call_01)]` → the second thread's assistant message lacks reasoning → conversation stuck (retries rebuild the same request).

## Changes

- `743d1a6` — `transformMessages` keeps `pendingReasoning` alive across assistant flushes: replaced by the next `thinking` block, cleared at user/context boundaries. Every assistant tool_use message of a turn now carries the turn's chain-of-thought.
- Regression test `TestEchoReasoningContentCoversSplitAssistantTurns` reproduces the exact wire shape (two use/result pairs, one thinking block) and asserts both assistant messages carry `reasoning_content`. Verified to fail on the pre-fix code.

## Verification

- `go test ./cmd/juggler/providers/openaibase/` — ok (all tests, including the new one; the new test fails without the client change).
- `go test ./cmd/juggler/providers/...` — ok.
- Live API probe (deepseek-v4-flash, thinking enabled): failing shape → 400 with the exact error; fixed shape → 200. One call each, ~1k tokens total.
- Not verified: a full conversation end-to-end in a rebuilt binary (the public repo cannot build the GUI binary — `3rdparty/wails/v3` is a private replacement directory), and other `EchoReasoningContent` vendors (GLM, Kimi, Moonshot) with the repeated echo.

## Deferred

- Non-thinking mode toggle for DeepSeek v4 (per-conversation escape hatch; currently no ThinkingSpec levels are advertised so the UI offers no switch).
