### PR TITLE
Skip rendering transcript rows scrolled out of view

### DIFF
--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -1330,6 +1330,60 @@ conversation-message-list-wrapper {
     margin-bottom: auto;
 }
 
+/* Let WebKit skip rendering work for transcript rows scrolled out of view.
+
+   The transcript is fully materialised: every item a conversation has ever
+   produced stays in the DOM (there is no windowing layer, and nothing prunes
+   old rows). WebKit's rendering update walks the render tree, so the cost of
+   style recalc + layout + paint scales with the WHOLE conversation rather than
+   with what's on screen. On a long thread that pins the WebProcess main thread
+   near saturation for as long as anything keeps invalidating — and something
+   always does while a turn is in flight (the busy spinner animates
+   continuously) — and because the GTK shell has to composite each of those
+   frames, one heavy window makes every window in the app stutter.
+
+   Accelerated compositing does not fix this: it moves rasterisation to the GPU,
+   but the render-tree traversal and geometry stay on the main thread.
+
+   content-visibility:auto lets the engine skip style, layout and paint for rows
+   outside the viewport (plus its own margin), so per-frame cost tracks what is
+   visible instead of how long the conversation has grown. It changes only
+   *rendering* — the DOM is untouched — so the things that read the transcript
+   keep working unchanged:
+     - find-controller walks text nodes into Ranges and filters visibility on
+       the `hidden`/`aria-hidden` attributes, never on offsetParent or layout,
+       so off-screen matches are still found; its scrollIntoView renders the row
+       on the way to it, and the Custom Highlight paints once it does.
+     - tooltips and popup surfaces are appended to document.body, so the paint
+       containment content-visibility implies cannot clip them. Nothing inside a
+       message row paints outside its own box.
+     - selection and copy follow DOM order, which is unchanged.
+
+   Deliberately NOT excluding the newest rows (e.g. :not(:nth-last-child(-n+N))
+   to keep the streaming bubble out of it): a structural pseudo-class on a list
+   this long makes every insertion invalidate sibling style, which is the very
+   per-item cost this rule exists to remove. It isn't needed anyway — the rows
+   being streamed into sit at the bottom, on screen, so they render normally;
+   and the FLIP height read (offsetHeight) forces layout on demand regardless.
+
+   contain-intrinsic-size supplies placeholder geometry for rows the engine has
+   not laid out yet. The `auto` keyword makes it remember each row's last real
+   size, so scrollbar geometry settles once a row has been seen — which matters
+   in this reversed, bottom-anchored scroller, where an estimate that changed
+   while scrolling up would shift content under the pointer. The 6rem fallback
+   is a typical short bubble; it only ever applies to a row not yet rendered
+   once. */
+.conversation-message-list-inner > user-message,
+.conversation-message-list-inner > assistant-message,
+.conversation-message-list-inner > thinking-message,
+.conversation-message-list-inner > tool-action-message,
+.conversation-message-list-inner > thread-message,
+.conversation-message-list-inner > context-item-message,
+.conversation-message-list-inner > error-message {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 6rem;
+}
+
 .conversation-message-list::-webkit-scrollbar {
     width: 0.375rem;
 }


### PR DESCRIPTION
## Problem

A window with a long conversation pins its WebKit `WebProcess` **main thread** near saturation and keeps it there, which makes the whole app stutter — the GTK shell has to composite each of those frames, and all windows share it.

Measured on a live app (per-thread `/proc` sampling, then `gdb` stacks):

| window | transcript | WebProcess CPU |
|---|---|---|
| A | 604 tool-use items, ~16 MB doc | **88%** (state `R`) |
| B | 378 tool-use items, ~23 MB doc | **74%** |
| C | conversations of a few hundred bytes | **~0%** |

Inside the hot renderer, ~100% of the cost is the **main thread**: `JITWorker` 2.0%, `HeapHelper`/GC 0.5% each. A JavaScript busy-loop would drag JIT and GC up with it — this is rendering work. The `gdb` stacks land in WebKit's rendering-update timer doing a recursive render-tree walk (`WTF::RunLoop::run → g_main_context_dispatch → … → __roundf`).

The backend is **not** involved: the server logged 0–2 lines per 2s while its renderer sat at ~90%. CPU tracks **transcript size**, not activity.

## Cause

The transcript is **fully materialised** — every item a conversation has ever produced stays in the DOM. There is no windowing layer, nothing prunes old rows, and no containment hint anywhere on the message list. WebKit's rendering update walks the render tree, so **style recalc + layout + paint scale with the whole conversation** rather than with what is on screen. At 604 tool-action rows — each with nested markdown, code blocks and syntax-highlighted spans — that is a very large tree re-walked on every rendering update.

Two things this is **not**, both ruled out by experiment:

- **Not the animations.** Toggling `prefers-reduced-motion` changed nothing (70% → 68%, within noise).
- **Not fixable by GPU acceleration.** With acceleration enabled (renderers hold a DRI render node; the startup log reports it on) the profile is unchanged. Accelerated compositing moves *rasterisation* to the GPU — the render-tree traversal and geometry stay on the main thread.

## Fix

`content-visibility: auto` on the transcript rows, so the engine may skip style, layout and paint for rows outside the viewport (plus its own margin). Per-frame cost then tracks what is visible instead of how long the conversation has grown. One CSS rule, 54 lines including the rationale comment.

It changes only **rendering** — the DOM is untouched — so everything that reads the transcript keeps working. I checked each consumer rather than assuming:

- **Find** — `find-controller` walks text nodes into `Range`s and filters visibility on the `hidden`/`aria-hidden` **attributes**, explicitly *not* on `offsetParent`/layout (there's a comment saying why: the reversed scroller makes those unreliable). So off-screen matches are still found; `scrollIntoView` renders the row on the way to it, and the CSS Custom Highlight paints once it does.
- **Tooltips / popups** — appended to `document.body` (`tooltip-manager.js`, `popup-surface.js`), so the paint containment `content-visibility` implies cannot clip them. I checked for absolutely-positioned escapees inside message scopes; there are none.
- **Selection / copy** — follow DOM order, unchanged.

`contain-intrinsic-size: auto 6rem` supplies placeholder geometry for rows not yet laid out. The **`auto` keyword** makes each row remember its last real size, so scrollbar geometry settles once a row has been seen — this matters in the reversed, bottom-anchored scroller, where an estimate that shifted while scrolling up would move content under the pointer. The `6rem` fallback is a typical short bubble and only ever applies to a row not yet rendered once.

### One deliberate non-choice

I did **not** exclude the newest rows (e.g. `:not(:nth-last-child(-n+N))` to keep the streaming bubble out of it). A structural pseudo-class on a list this long makes every insertion invalidate sibling style — precisely the per-item cost this rule exists to remove. It isn't needed anyway: the rows being streamed into sit at the bottom, on screen, so they render normally, and the FLIP height read (`offsetHeight`) forces layout on demand regardless.

## Testing

`make lint-css` / `make lint-js` / `make lint-types` — all clean.

**Not verified at runtime, and worth a reviewer's eye:** I could not measure the improvement in a running build (no WebKitGTK browser on this box, and I wasn't going to point a client at a live session). The reasoning and the consumer audit above are solid, but the actual frame-cost win — and the scroll feel in the reversed scroller, which is the one place `content-visibility` can surprise you — should be confirmed on a long conversation before merging.

Independent of the GPU work in #48; they address different halves of the same symptom (that one moves rasterisation off the CPU, this one stops the main thread walking the whole transcript).
