### PR TITLE
Build the worker envelope without re-encoding the payload (64% of server CPU)

### DIFF
--- a/cmd/juggler/worker/sync.go
+++ b/cmd/juggler/worker/sync.go
@@ -6,6 +6,8 @@ package worker
 
 import (
 	"encoding/json"
+
+	"github.com/buger/jsonparser"
 )
 
 // WorkerMessage is the format for messages to/from Go worker via WebSocket.
@@ -16,23 +18,85 @@ type WorkerMessage struct {
 	Payload        json.RawMessage `json:"payload"`        // Message payload
 }
 
+// The envelope's literal segments. Concatenated with the two quoted strings and
+// the payload they spell exactly what marshalling WorkerMessage produces —
+// same fields, same order — so the wire format is unchanged.
+const (
+	envelopeHead    = `{"type":"worker-message","conversationId":`
+	envelopeMsgType = `,"workerMsgType":`
+	envelopePayload = `,"payload":`
+)
+
 // FormatWorkerMessage creates a worker message for sending to browser.
+//
+// This is the server's hottest function: every worker message bound for a
+// viewer passes through it, once per recipient. It used to build the envelope
+// with encoding/json, which walked the entire payload TWICE just to add a
+// ~90-byte wrapper:
+//
+//   - json.Unmarshal(workerMsg, &generic) to read one field, "type" — but
+//     Unmarshal runs checkValid over the whole document first.
+//   - json.Marshal(msg) with Payload as a json.RawMessage — the encoder runs
+//     appendCompact over the whole payload again, copying it into a growing
+//     bytes.Buffer.
+//
+// Profiling a viewer sync on a large conversation (a ~55MB Yjs doc) put this
+// one function at 64% of all server CPU — appendCompact 39%, checkValid 23% —
+// and a heap profile attributed 290MB of live heap to its envelope buffers,
+// against only ~76MB of actual CRDT data.
+//
+// Neither pass buys anything. The payload is ALWAYS the output of a successful
+// json.Marshal in this same process: its only producers are
+// ConversationWorker.send and ConversationWorker.reply, which both marshal and
+// return early if that fails (see worker.go), so nothing else can reach here.
+// The bytes are therefore already valid and already compact, and re-validating
+// then re-compacting them is pure overhead.
+//
+// So the envelope is assembled by appending into one exactly-sized buffer with
+// the payload copied verbatim — a single memmove, no scan, no reallocation.
 func FormatWorkerMessage(conversationID string, workerMsg []byte) []byte {
-	// Parse the worker message to get its type
-	var generic struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(workerMsg, &generic); err != nil {
+	// Cheapest possible sanity check on the payload, in O(1): every producer
+	// marshals a struct or map, so the bytes must open and close a JSON object.
+	// This is not validation — that is the pass being removed — but it costs two
+	// byte comparisons and still rejects the one corruption that would otherwise
+	// put malformed JSON on the wire: a truncated payload, whose "type" is
+	// readable even though the document never closes. Anything subtler cannot
+	// occur, because the only producers marshal with encoding/json and drop the
+	// message if that fails.
+	if len(workerMsg) < 2 || workerMsg[0] != '{' || workerMsg[len(workerMsg)-1] != '}' {
 		return nil
 	}
 
-	msg := WorkerMessage{
-		Type:           "worker-message",
-		ConversationID: conversationID,
-		WorkerMsgType:  generic.Type,
-		Payload:        workerMsg,
+	// Read "type" without validating the whole document. Every producer declares
+	// Type as its first struct field, so encoding/json emits it first and this
+	// stops after a few bytes. An error — a missing or non-string "type", or
+	// JSON too broken to reach it — means the envelope can't be labelled, which
+	// is the same nil the old Unmarshal failure returned.
+	msgType, err := jsonparser.GetString(workerMsg, "type")
+	if err != nil {
+		return nil
 	}
 
-	data, _ := json.Marshal(msg)
-	return data
+	// Both are short identifiers, so marshalling them individually is cheap and
+	// escapes them exactly as encoding/json would inside the struct.
+	convIDJSON, err := json.Marshal(conversationID)
+	if err != nil {
+		return nil
+	}
+	msgTypeJSON, err := json.Marshal(msgType)
+	if err != nil {
+		return nil
+	}
+
+	buf := make([]byte, 0,
+		len(envelopeHead)+len(convIDJSON)+
+			len(envelopeMsgType)+len(msgTypeJSON)+
+			len(envelopePayload)+len(workerMsg)+1)
+	buf = append(buf, envelopeHead...)
+	buf = append(buf, convIDJSON...)
+	buf = append(buf, envelopeMsgType...)
+	buf = append(buf, msgTypeJSON...)
+	buf = append(buf, envelopePayload...)
+	buf = append(buf, workerMsg...)
+	return append(buf, '}')
 }

--- a/cmd/juggler/worker/sync_format_test.go
+++ b/cmd/juggler/worker/sync_format_test.go
@@ -1,0 +1,184 @@
+//     ▄▄ ▄▄ ▄▄  ▄▄▄▄  ▄▄▄▄ ▄▄    ▄▄▄▄▄ ▄▄▄▄
+//     ██ ██ ██ ██ ▄▄ ██ ▄▄ ██    ██▄▄  ██▄█▄   Copyright (c) 2026 Julian Storer
+//   ▄▄█▀ ▀███▀ ▀███▀ ▀███▀ ██▄▄▄ ██▄▄▄ ██ ██   AGPL-3.0-or-later - see LICENSE
+
+package worker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// formatWorkerMessageEncodingJSON is the previous encoding/json implementation,
+// kept verbatim as the reference oracle: the optimised FormatWorkerMessage must
+// produce byte-identical output for every payload the server can actually
+// generate, or the wire format has silently changed.
+func formatWorkerMessageEncodingJSON(conversationID string, workerMsg []byte) []byte {
+	var generic struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(workerMsg, &generic); err != nil {
+		return nil
+	}
+	msg := WorkerMessage{
+		Type:           "worker-message",
+		ConversationID: conversationID,
+		WorkerMsgType:  generic.Type,
+		Payload:        workerMsg,
+	}
+	data, _ := json.Marshal(msg)
+	return data
+}
+
+// realisticPayloads returns payloads shaped like the ones the worker actually
+// sends. Each is produced by json.Marshal, which is the invariant the optimised
+// path relies on: ConversationWorker.send and .reply are the only producers and
+// both marshal (and bail on error), so a payload is always valid, compact,
+// already-HTML-escaped encoder output.
+//
+// Building them with json.Marshal rather than hand-written literals is
+// deliberate — it is exactly the class of input that reaches the function, and
+// it pins the equivalence claim to reality rather than to a guess about it.
+func realisticPayloads(t testingTB) map[string][]byte {
+	t.Helper()
+	blob := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 4096) // base64s in the JSON
+	cases := map[string]any{
+		"yjs-sync": YjsSyncMessage{Type: "yjs-sync", Bytes: blob},
+		"yjs-sync-engine-derived": YjsSyncMessage{
+			Type: "yjs-sync", Bytes: blob, EngineDerived: true,
+		},
+		// Characters encoding/json escapes: <, >, & become \u003c/\u003e/\u0026,
+		// so the old path's HTML-escaping compaction pass had nothing left to do
+		// — which is why copying the payload verbatim is equivalent.
+		"html-ish-content": map[string]any{
+			"type": "status",
+			"text": `<script>a && b > c</script>`,
+		},
+		"unicode-and-escapes": map[string]any{
+			"type": "status",
+			"text": "emoji 🤹 quote \" backslash \\ newline \n tab \t",
+		},
+		"nested-structure": map[string]any{
+			"type": "ready",
+			"metadata": map[string]any{
+				"items":  []any{1, 2.5, true, nil, "x"},
+				"nested": map[string]any{"deep": map[string]any{"deeper": "value"}},
+			},
+		},
+		"empty-object-payload": map[string]any{"type": "ping"},
+	}
+	out := make(map[string][]byte, len(cases))
+	for name, v := range cases {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("fixture %q failed to marshal: %v", name, err)
+		}
+		out[name] = b
+	}
+	return out
+}
+
+// testingTB is the subset of testing.TB the fixtures need, so the same builder
+// serves both the tests and the benchmarks.
+type testingTB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+func TestFormatWorkerMessageMatchesEncodingJSON(t *testing.T) {
+	convIDs := []string{
+		"conv_vhwcsgd83",
+		"", // defensive: an unset conversation id must still round-trip
+		`conv_with_"quote"_and_\backslash`,
+		"conv_🤹_unicode",
+	}
+	for name, payload := range realisticPayloads(t) {
+		for i, convID := range convIDs {
+			t.Run(fmt.Sprintf("%s/convID%d", name, i), func(t *testing.T) {
+				want := formatWorkerMessageEncodingJSON(convID, payload)
+				got := FormatWorkerMessage(convID, payload)
+				if !bytes.Equal(got, want) {
+					t.Errorf("envelope differs from encoding/json\n got: %s\nwant: %s",
+						truncate(got), truncate(want))
+				}
+				// And it must still be valid JSON that decodes to the same envelope.
+				var back WorkerMessage
+				if err := json.Unmarshal(got, &back); err != nil {
+					t.Fatalf("envelope is not valid JSON: %v", err)
+				}
+				if back.Type != "worker-message" || back.ConversationID != convID {
+					t.Errorf("decoded envelope wrong: type=%q convID=%q", back.Type, back.ConversationID)
+				}
+				if !bytes.Equal(back.Payload, payload) {
+					t.Error("payload did not survive the round trip byte-for-byte")
+				}
+			})
+		}
+	}
+}
+
+func TestFormatWorkerMessageRejectsUnusable(t *testing.T) {
+	cases := map[string][]byte{
+		"nil":              nil,
+		"empty":            {},
+		"not json":         []byte("not json at all"),
+		"truncated":        []byte(`{"type":"yjs-sync"`),
+		"missing type":     []byte(`{"bytes":"AAAA"}`),
+		"non-string type":  []byte(`{"type":123}`),
+		"array not object": []byte(`["type","yjs-sync"]`),
+	}
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := FormatWorkerMessage("conv_x", payload); got != nil {
+				t.Errorf("expected nil for unusable payload, got %s", truncate(got))
+			}
+		})
+	}
+}
+
+func truncate(b []byte) string {
+	const max = 200
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + fmt.Sprintf("… (%d bytes)", len(b))
+}
+
+// benchPayload builds a yjs-sync message of roughly the given size — the shape
+// that dominates a viewer sync, and the reason this function showed up at 64%
+// of server CPU in a profile.
+func benchPayload(b *testing.B, approxBytes int) []byte {
+	b.Helper()
+	blob := bytes.Repeat([]byte{0x01, 0x02, 0x03}, approxBytes/4)
+	payload, err := json.Marshal(YjsSyncMessage{Type: "yjs-sync", Bytes: blob})
+	if err != nil {
+		b.Fatalf("marshal fixture: %v", err)
+	}
+	return payload
+}
+
+func BenchmarkFormatWorkerMessage(b *testing.B) {
+	for _, size := range []int{4 << 10, 256 << 10, 8 << 20} {
+		payload := benchPayload(b, size)
+		b.Run(fmt.Sprintf("new/%dKiB", len(payload)>>10), func(b *testing.B) {
+			b.SetBytes(int64(len(payload)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if FormatWorkerMessage("conv_vhwcsgd83", payload) == nil {
+					b.Fatal("unexpected nil")
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("old_encoding_json/%dKiB", len(payload)>>10), func(b *testing.B) {
+			b.SetBytes(int64(len(payload)))
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if formatWorkerMessageEncodingJSON("conv_vhwcsgd83", payload) == nil {
+					b.Fatal("unexpected nil")
+				}
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/anthropics/anthropic-sdk-go v1.61.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/buger/jsonparser v1.6.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofrs/flock v0.13.0
@@ -34,7 +35,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.6.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coder/websocket v1.8.15 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect


### PR DESCRIPTION
## Problem

`FormatWorkerMessage` wraps every worker message bound for a viewer, once per recipient. It built the envelope with `encoding/json`, which walked the **entire payload twice** just to add a ~90-byte wrapper:

- `json.Unmarshal(workerMsg, &generic)` to read one field, `"type"` — but `Unmarshal` runs `checkValid` over the whole document first.
- `json.Marshal(msg)` with `Payload` as a `json.RawMessage` — the encoder runs `appendCompact` over the whole payload again, copying it into a growing `bytes.Buffer`.

I went looking for this because the `juggler` server was sitting at 200–330% CPU with a 2.4–2.9 GB RSS that sawtoothed ~500 MB per GC cycle. A **CPU profile** of a viewer sync against a large conversation (a 55 MB Yjs doc in a 1.2 GB store) put this one function at **64% of all server CPU**:

```
juggler/cmd/juggler/worker.FormatWorkerMessage ......... 3.52s  64.1%
  ├─ encoding/json.Marshal ............................. 3.06s  55.7%
  │    └─ encoding/json.appendCompact .................. 2.15s  39.2%   ← re-compacting
  └─ encoding/json.Unmarshal ........................... 1.72s  31.3%
       └─ encoding/json.checkValid ..................... 1.25s  22.8%   ← re-validating
```

A **heap profile** of the same server attributed **461 MB of live heap (84%) to `json.Marshal`** — 290 MB of it to this function's envelope buffers — against only ~76 MB of actual CRDT data. That garbage is what drives the GC churn.

## Why both passes are unnecessary

The payload is **always the output of a successful `json.Marshal` in this same process**. Its only producers are `ConversationWorker.send` and `ConversationWorker.reply`, which both marshal and return early if that fails (`worker.go`), so nothing else can reach here. The bytes are already valid and already compact — re-validating and re-compacting them is pure overhead.

The old path's HTML-escaping compaction was likewise a no-op: the producers' own `Marshal` has already escaped `<`, `>` and `&`, so there was never anything left to escape.

## Fix

Assemble the envelope by appending into **one exactly-sized buffer** with the payload copied verbatim — a single `memmove`, no scan, no reallocation. The type is read with `jsonparser.GetString`, which stops at the first key instead of validating the document; every producer declares `Type` as its first struct field, so it reads a few bytes. `jsonparser` was already in the module graph as an indirect dependency, so this only promotes it to direct (`go.sum` unchanged).

Payloads are still rejected in **O(1)** when they don't open and close a JSON object. That isn't validation — that's the pass being removed — but it costs two byte comparisons and rejects the one corruption that could otherwise put malformed JSON on the wire: a **truncated** payload, whose `"type"` stays readable even though the document never closes. (I hit exactly this while writing the tests, which is why the guard is there.)

**The wire format is unchanged** — the output is byte-for-byte what the struct marshalled before, same fields, same order.

## Correctness

A test asserts that equivalence against the **previous implementation, kept verbatim as an oracle**, over payloads built the way the worker builds them (`json.Marshal` output: `yjs-sync` blobs, HTML-escapable characters, unicode, escapes, nesting) × conversation ids containing quotes, backslashes and unicode. Building fixtures with `json.Marshal` rather than hand-written literals is deliberate: that's exactly the class of input that reaches the function, so the equivalence claim is pinned to reality rather than to a guess about it. Each result is also re-decoded to confirm the payload survives byte-for-byte.

## Benchmark

```
BenchmarkFormatWorkerMessage        old              new          speedup
  4 KiB payload               61053 ns/op       2236 ns/op          27x
256 KiB payload             2387999 ns/op      39452 ns/op          61x
  8 MiB payload            81221814 ns/op    1077031 ns/op          75x
```

Throughput on the 8 MiB case: **103 MB/s → 7789 MB/s**. Allocations 10 → 7 per call, 1.7 MB less allocated (one exactly-sized buffer instead of a doubling `bytes.Buffer`).

## End-to-end validation

Not just a microbenchmark — I re-ran the **identical** scenario (same 1.2 GB conversation, same headless viewer attaching and triggering a full-state sync) against a build with the fix, and re-profiled:

| | before | after |
|---|---|---|
| total CPU samples over the 25 s window | 5.49 s | **1.94 s** (−65%) |
| `FormatWorkerMessage` | 3.52 s (64.1%) | **0.12 s (6.2%)** (−97%) |
| `encoding/json.appendCompact` | 2.15 s (39.2%) | **absent** |
| peak CPU during the sync | 198% | **49%** |
| live heap after load | 550 MB | **150 MB** (−73%) |
| `json.Marshal` share of live heap | 461 MB (84%) | **absent from top** |
| process RSS with the conversation loaded | 1235 MB | **441 MB** (−64%) |

After the change the heap is dominated by the actual CRDT data (`y-crdt`, ~79 MB) rather than by JSON buffers — which is what you'd want it to look like.

## Testing

`make lint-fmt lint-go lint-deadcode` clean · `go build ./cmd/juggler` OK · `go test -count=1 -race -timeout 5m ./cmd/...` all pass (the CI command).

The profiling itself used a temporary `net/http/pprof` endpoint that is **not** part of this PR. If a diagnostic endpoint behind an env var would be welcome upstream, I'm happy to send it separately — it made this findable in minutes.
